### PR TITLE
feat(Authenticator): Adding primitives views

### DIFF
--- a/Sources/Authenticator/Views/Primitives/Button.swift
+++ b/Sources/Authenticator/Views/Primitives/Button.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+/// This Button follows Amplify UI theming.
 struct Button: View {
     @Environment(\.authenticatorTheme) var theme
     private var viewModifiers = ViewModifiers()

--- a/Sources/Authenticator/Views/Primitives/DatePicker.swift
+++ b/Sources/Authenticator/Views/Primitives/DatePicker.swift
@@ -7,6 +7,9 @@
 
 import SwiftUI
 
+/// This field allows the user to select a Date and parse it to a ISO-8601 format.
+/// It displays a label and a "Select date" button, which when tapped shows a native DatePicker
+/// This is done in order to allow not selecting anything, which the native component doesn't
 struct DatePicker: View {
     @Environment(\.isEnabled) private var isEnabled: Bool
     @Environment(\.authenticatorOptions) private var options
@@ -98,14 +101,6 @@ struct DatePicker: View {
         .background(backgroundColor)
         .animation(options.contentAnimation, value: validator.state)
 
-    }
-
-    private var imageName: String {
-        if actualDate == nil {
-            return "chevron.down.circle"
-        }
-
-        return "xmark.circle.fill"
     }
 
     private var tintColor: Color {

--- a/Sources/Authenticator/Views/Primitives/ImageButton.swift
+++ b/Sources/Authenticator/Views/Primitives/ImageButton.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+/// This is a convenient way of having a Button display a single known image
 struct ImageButton: View {
     private let image: Image
     private let action: () -> ()

--- a/Sources/Authenticator/Views/Primitives/PasswordField.swift
+++ b/Sources/Authenticator/Views/Primitives/PasswordField.swift
@@ -7,6 +7,9 @@
 
 import SwiftUI
 
+/// This field encapsulates a native TextField and a SecureField in a single component,
+/// providing a button to toggle betweem them, as is common.
+/// It also applies Amplify UI's theming
 struct PasswordField: View {
     @Environment(\.authenticatorTheme) var theme
     @ObservedObject private var validator: Validator
@@ -61,11 +64,11 @@ struct PasswordField: View {
                             validator.validate()
                         }
                     }
-    #if os(iOS)
+                #if os(iOS)
                     .autocapitalization(.none)
                     .frame(height: 25)
                     .padding([.top, .bottom, .leading], theme.Fields.style.padding)
-    #endif
+                #endif
                 if focusedField != nil, !text.isEmpty {
                     ImageButton(showPasswordImage) {
                         isShowingPassword.toggle()

--- a/Sources/Authenticator/Views/Primitives/PhoneNumberField.swift
+++ b/Sources/Authenticator/Views/Primitives/PhoneNumberField.swift
@@ -7,6 +7,10 @@
 
 import SwiftUI
 
+/// This field allows the user to enter a phone number
+/// It consists of two fields: one for the dialing code and one for the actual phone number
+/// and updates the associated Binding with the concatenation of both.
+/// It also applies Amplify UI's theming
 struct PhoneNumberField: View {
     @Environment(\.authenticatorTheme) var theme
     @ObservedObject private var validator: Validator
@@ -134,6 +138,8 @@ struct PhoneNumberField: View {
     }
 }
 
+/// This allows the user to select a dialing code from a list of all available ones,
+/// showing a localized name of the region associated with each code and its flag
 struct CountryCodeList: View {
     @Environment(\.authenticatorTheme) var theme
     @State private var searchCountry: String = ""

--- a/Sources/Authenticator/Views/Primitives/RadioButton.swift
+++ b/Sources/Authenticator/Views/Primitives/RadioButton.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+/// This represents a simple Button with a Radio Button-like look.
+/// It automatically toggles its state on tap
 struct RadioButton: View {
     @Environment(\.authenticatorTheme) var theme
     @Binding private var isSelected: Bool

--- a/Sources/Authenticator/Views/Primitives/TextField.swift
+++ b/Sources/Authenticator/Views/Primitives/TextField.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+/// This field allows the user to enter any text-based input
+/// It applies Amplify UI theming
 struct TextField: View {
     @Environment(\.authenticatorTheme) var theme
     @ObservedObject private var validator: Validator


### PR DESCRIPTION
**Description of changes:**

This PR ads all the **_primitives_** views that are used extensively by all the Authenticator views, i.e. views that represent small and reusable components such as `TextField`, `Button`, etc

All of these are `internal` as exposing/creating the Amplify UI primitives is out of scope for Authenticator

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
