### PR TITLE
test(Authenticator): Adding unit tests for all states

### DIFF
--- a/Tests/AuthenticatorTests/Mocks/MockAuthenticationService.swift
+++ b/Tests/AuthenticatorTests/Mocks/MockAuthenticationService.swift
@@ -1,0 +1,190 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+@testable import Authenticator
+import Foundation
+
+class MockAuthenticationService: AuthenticationService {
+
+    // MARK: - Sign In
+
+    var signInCount = 0
+    var mockedSignInResult: AuthSignInResult?
+    func signIn(username: String?, password: String?, options: AuthSignInRequest.Options?) async throws -> AuthSignInResult {
+        signInCount += 1
+        if let mockedSignInResult = mockedSignInResult {
+            return mockedSignInResult
+        }
+
+        throw AuthenticatorError.error(message: "Unable to sign in")
+    }
+
+    var confirmSignInCount = 0
+    var mockedConfirmSignInResult: AuthSignInResult?
+    func confirmSignIn(challengeResponse: String, options: AuthConfirmSignInRequest.Options?) async throws -> AuthSignInResult {
+        confirmSignInCount += 1
+        if let mockedConfirmSignInResult = mockedConfirmSignInResult {
+            return mockedConfirmSignInResult
+        }
+
+        throw AuthenticatorError.error(message: "Unable to confirm sign in")
+    }
+
+    var mockedCurrentUser: AuthUser?
+    func getCurrentUser() async throws -> AuthUser {
+        if let mockedCurrentUser = mockedCurrentUser {
+            return mockedCurrentUser
+        }
+
+        throw AuthenticatorError.error(message: "Unable to retrieve Current User")
+    }
+
+    // MARK: - Reset Password
+
+    var resetPasswordCount = 0
+    var mockedResetPasswordResult: AuthResetPasswordResult?
+    func resetPassword(for username: String, options: AuthResetPasswordRequest.Options?) async throws -> AuthResetPasswordResult {
+        resetPasswordCount += 1
+        if let mockedResetPasswordResult = mockedResetPasswordResult {
+            return mockedResetPasswordResult
+        }
+
+        throw AuthenticatorError.error(message: "Unable to reset password")
+    }
+
+    var confirmResetPasswordCount = 0
+    var mockedConfirmResetPasswordError: AuthenticatorError?
+    func confirmResetPassword(for username: String, with newPassword: String, confirmationCode: String, options: AuthConfirmResetPasswordRequest.Options?) async throws {
+        confirmResetPasswordCount += 1
+        if let error = mockedConfirmResetPasswordError {
+            throw error
+        }
+    }
+
+    // MARK: - Sign Up
+
+    var signUpCount = 0
+    var mockedSignUpResult: AuthSignUpResult?
+    func signUp(username: String, password: String?, options: AuthSignUpRequest.Options?) async throws -> AuthSignUpResult {
+        signUpCount += 1
+        if let mockedSignUpResult = mockedSignUpResult {
+            return mockedSignUpResult
+        }
+        throw AuthenticatorError.error(message: "Unable to sign up")
+    }
+
+    var confirmSignUpCount = 0
+    var mockedConfirmSignUpResult: AuthSignUpResult?
+    func confirmSignUp(for username: String, confirmationCode: String, options: AuthConfirmSignUpRequest.Options?) async throws -> AuthSignUpResult {
+        confirmSignUpCount += 1
+        if let mockedConfirmSignUpResult = mockedConfirmSignUpResult {
+            return mockedConfirmSignUpResult
+        }
+
+        throw AuthenticatorError.error(message: "Unable to confirm sign up")
+    }
+
+    var resendSignUpCodeCount = 0
+    var mockedResendSignUpCodeResult: AuthCodeDeliveryDetails?
+    func resendSignUpCode(for username: String, options: AuthResendSignUpCodeRequest.Options?) async throws -> AuthCodeDeliveryDetails {
+        resendSignUpCodeCount += 1
+        if let mockedResendSignUpCodeResult = mockedResendSignUpCodeResult {
+            return mockedResendSignUpCodeResult
+        }
+        throw AuthenticatorError.error(message: "Unable to resend sign up code")
+    }
+
+    // MARK: - Verify User
+
+    var fetchUserAttributesCount = 0
+    var mockedUnverifiedAttributes: [AuthUserAttribute] = []
+    func fetchUserAttributes(options: AuthFetchUserAttributesRequest.Options?) async throws -> [AuthUserAttribute] {
+        fetchUserAttributesCount += 1
+        return mockedUnverifiedAttributes
+    }
+
+    var resendConfirmationCodeForAttributeCount = 0
+    var mockedResendConfirmationCodeForAttributeResult: AuthCodeDeliveryDetails?
+    func resendConfirmationCode(forUserAttributeKey userAttributeKey: AuthUserAttributeKey, options: AuthAttributeResendConfirmationCodeRequest.Options?) async throws -> AuthCodeDeliveryDetails {
+        resendConfirmationCodeForAttributeCount += 1
+        if let mockedResendConfirmationCodeForAttributeResult = mockedResendConfirmationCodeForAttributeResult {
+            return mockedResendConfirmationCodeForAttributeResult
+        }
+
+        throw AuthenticatorError.error(message: "Unable to resend confirmation code for attribute")
+    }
+
+    var confirmUserAttributeCount = 0
+    var mockedConfirmUserAttributeError: AuthenticatorError?
+    func confirm(userAttribute: AuthUserAttributeKey, confirmationCode: String, options: AuthConfirmUserAttributeRequest.Options?) async throws {
+        confirmUserAttributeCount += 1
+        if let mockedConfirmUserAttributeError = mockedConfirmUserAttributeError {
+            throw mockedConfirmUserAttributeError
+        }
+    }
+
+    // MARK: - Sign Out
+
+    var signOutCount = 0
+    var mockedSignOutResult: AuthSignOutResult?
+    func signOut(options: AuthSignOutRequest.Options?) async -> AuthSignOutResult {
+        signOutCount += 1
+        return SignOutResult()
+    }
+
+    // MARK: - Web UI
+
+    func signInWithWebUI(presentationAnchor: AuthUIPresentationAnchor?, options: AuthWebUISignInRequest.Options?) async throws -> AuthSignInResult {
+        return .init(nextStep: .done)
+    }
+
+    func signInWithWebUI(for authProvider: AuthProvider, presentationAnchor: AuthUIPresentationAnchor?, options: AuthWebUISignInRequest.Options?) async throws -> AuthSignInResult {
+        return .init(nextStep: .done)
+    }
+
+    // MARK: - User management
+
+    func fetchAuthSession(options: AuthFetchSessionRequest.Options?) async throws -> AuthSession {
+        return Session(isSignedIn: true)
+    }
+
+    func update(userAttribute: AuthUserAttribute, options: AuthUpdateUserAttributeRequest.Options?) async throws -> AuthUpdateAttributeResult {
+        return .init(isUpdated: true, nextStep: .done)
+    }
+
+    func update(userAttributes: [AuthUserAttribute], options: AuthUpdateUserAttributesRequest.Options?) async throws -> [AuthUserAttributeKey: AuthUpdateAttributeResult] {
+        return [:]
+    }
+
+    func update(oldPassword: String, to newPassword: String, options: AuthChangePasswordRequest.Options?) async throws {}
+
+    func deleteUser() async throws {}
+
+    // MARK: - Device management
+
+    func fetchDevices(options: AuthFetchDevicesRequest.Options?) async throws -> [AuthDevice] {
+        return []
+    }
+
+    func forgetDevice(_ device: AuthDevice?, options: AuthForgetDeviceRequest.Options?) async throws {}
+
+    func rememberDevice(options: AuthRememberDeviceRequest.Options?) async throws {}
+}
+
+extension MockAuthenticationService {
+    struct User: AuthUser {
+        var username: String
+        var userId: String
+    }
+
+    struct SignOutResult: AuthSignOutResult {}
+
+    struct Session: AuthSession {
+        var isSignedIn: Bool
+    }
+}

--- a/Tests/AuthenticatorTests/Mocks/MockAuthenticatorState.swift
+++ b/Tests/AuthenticatorTests/Mocks/MockAuthenticatorState.swift
@@ -1,0 +1,39 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+@testable import Authenticator
+
+class MockAuthenticatorState: AuthenticatorStateProtocol {
+    var authenticationService: AuthenticationService = MockAuthenticationService()
+
+    var configuration = CognitoConfiguration(
+        usernameAttributes: [],
+        signupAttributes: [],
+        passwordProtectionSettings: .init(minLength: 0, characterPolicy: []),
+        verificationMechanisms: []
+    )
+
+    var setCurrentStepCount = 0
+    var setCurrentStepValue: Step?
+    func setCurrentStep(_ step: Step) {
+        setCurrentStepCount += 1
+        setCurrentStepValue = step
+    }
+
+    var mockedStep: Step?
+    var step: Step {
+        return mockedStep ?? .loading
+    }
+
+    var moveToCount = 0
+    var moveToValue: AuthenticatorInitialStep?
+    func move(to initialStep: AuthenticatorInitialStep) {
+        moveToCount += 1
+        moveToValue = initialStep
+    }
+}

--- a/Tests/AuthenticatorTests/States/AuthenticatorBaseStateTests.swift
+++ b/Tests/AuthenticatorTests/States/AuthenticatorBaseStateTests.swift
@@ -1,0 +1,256 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+@testable import Authenticator
+import AWSCognitoAuthPlugin
+import XCTest
+
+class AuthenticatorBaseStateTests: XCTestCase {
+    private var state: AuthenticatorBaseState!
+    private var authenticationService: MockAuthenticationService!
+
+    override func setUp() {
+        state = AuthenticatorBaseState(credentials: Credentials())
+        let authenticatorState = AuthenticatorState()
+        authenticationService = MockAuthenticationService()
+        authenticatorState.authenticationService = authenticationService
+        state.configure(with: authenticatorState)
+    }
+
+    override func tearDown() {
+        state = nil
+        authenticationService = nil
+    }
+
+    func testNextStep_forSignIn_withDone_andAllUnverifiedAttributes_shouldFetchUserAttributes() async throws {
+        authenticationService.mockedUnverifiedAttributes = [
+            .init(.phoneNumberVerified, value: "false"),
+            .init(.emailVerified, value: "false")
+        ]
+
+        let result = AuthSignInResult(nextStep: .done)
+        let nextStep = try await state.nextStep(for: result)
+        XCTAssertEqual(authenticationService.fetchUserAttributesCount, 1)
+        guard case .verifyUser(let attributes) = nextStep else {
+            XCTFail("Expected next step to be verifyUser,was \(nextStep)")
+            return
+        }
+        XCTAssertEqual(attributes.count, 2)
+        XCTAssertTrue(attributes.contains(where: { $0 == .email || $0 == .phoneNumber }))
+    }
+
+    func testNextStep_forSignIn_withDone_andSomeUnverifiedAttributes_shouldFetchUserAttributes() async throws {
+        authenticationService.mockedUnverifiedAttributes = [
+            .init(.phoneNumberVerified, value: "false"),
+            .init(.emailVerified, value: "true")
+        ]
+        authenticationService.mockedCurrentUser = MockAuthenticationService.User(
+            username: "username",
+            userId: "userId"
+        )
+
+        let result = AuthSignInResult(nextStep: .done)
+        let nextStep = try await state.nextStep(for: result)
+        XCTAssertEqual(authenticationService.fetchUserAttributesCount, 1)
+        guard case .signedIn(let user) = nextStep else {
+            XCTFail("Expected next step to be signedIn, was \(nextStep)")
+            return
+        }
+        XCTAssertEqual(user.username, "username")
+        XCTAssertEqual(user.userId, "userId")
+    }
+
+    func testNextStep_forSignIn_withDone_andAllVerifiedAttributes_shouldFetchUserAttributes() async throws {
+        authenticationService.mockedUnverifiedAttributes = [
+            .init(.phoneNumberVerified, value: "true"),
+            .init(.emailVerified, value: "true")
+        ]
+        authenticationService.mockedCurrentUser = MockAuthenticationService.User(
+            username: "username",
+            userId: "userId"
+        )
+
+        let result = AuthSignInResult(nextStep: .done)
+        let nextStep = try await state.nextStep(for: result)
+        XCTAssertEqual(authenticationService.fetchUserAttributesCount, 1)
+        guard case .signedIn(let user) = nextStep else {
+            XCTFail("Expected next step to be signedIn, was \(nextStep)")
+            return
+        }
+        XCTAssertEqual(user.username, "username")
+        XCTAssertEqual(user.userId, "userId")
+    }
+
+    func testNextStep_forSignIn_withConfirmSignInWithSMSMFACode_shouldReturnConfirmSignInWithMFACode() async throws {
+        let destination = DeliveryDestination.email("email@email.com")
+        let result = AuthSignInResult(
+            nextStep: .confirmSignInWithSMSMFACode(
+                .init(destination: destination),
+                nil
+            )
+        )
+        let nextStep = try await state.nextStep(for: result)
+        guard case .confirmSignInWithMFACode(let deliveryDetails) = nextStep else {
+            XCTFail("Expected next step to be confirmSignInWithMFACode, was \(nextStep)")
+            return
+        }
+        XCTAssertNotNil(deliveryDetails)
+        XCTAssertEqual(deliveryDetails?.destination, destination)
+    }
+
+    func testNextStep_forSignIn_withConfirmSignInWithCustomChallenge_shouldReturnConfirmSignInWithCustomChallenge() async throws {
+        let result = AuthSignInResult(nextStep: .confirmSignInWithCustomChallenge(nil))
+        let nextStep = try await state.nextStep(for: result)
+        guard case .confirmSignInWithCustomChallenge = nextStep else {
+            XCTFail("Expected next step to be confirmSignInWithCustomChallenge, was \(nextStep)")
+            return
+        }
+    }
+
+    func testNextStep_forSignIn_withConfirmSignInWithNewPassword_shouldReturnConfirmSignInWithNewPassword() async throws {
+        let result = AuthSignInResult(nextStep: .confirmSignInWithNewPassword(nil))
+        let nextStep = try await state.nextStep(for: result)
+        guard case .confirmSignInWithNewPassword = nextStep else {
+            XCTFail("Expected next step to be confirmSignInWithNewPassword, was \(nextStep)")
+            return
+        }
+    }
+
+    func testNextStep_forSignIn_withConfirmSignUp_shouldReturnConfirmSignUp() async throws {
+        let result = AuthSignInResult(nextStep: .confirmSignUp(nil))
+        let nextStep = try await state.nextStep(for: result)
+        guard case .confirmSignUp(let deliveryDetails) = nextStep else {
+            XCTFail("Expected next step to be confirmSignUp, was \(nextStep)")
+            return
+        }
+        XCTAssertNil(deliveryDetails)
+    }
+
+    func testNextStep_forSignIn_withResetPassword_andConfirmResetPassword_shouldCallResetPassword_andReturnConfirmResetPassword() async throws {
+        let destination = DeliveryDestination.email("email@email.com")
+        let signInResult = AuthSignInResult(nextStep: .resetPassword(nil))
+        authenticationService.mockedResetPasswordResult = AuthResetPasswordResult(
+            isPasswordReset: false,
+            nextStep: .confirmResetPasswordWithCode(
+                .init(destination: destination),
+                nil
+            )
+        )
+        let nextStep = try await state.nextStep(for: signInResult)
+        XCTAssertEqual(authenticationService.resetPasswordCount, 1)
+        guard case .confirmResetPassword(let deliveryDetails) = nextStep else {
+            XCTFail("Expected next step to be confirmResetPassword, was \(nextStep)")
+            return
+        }
+        XCTAssertNotNil(deliveryDetails)
+        XCTAssertEqual(deliveryDetails?.destination, destination)
+    }
+
+    func testNextStep_forSignIn_withResetPassword_andDone_shouldCallResetPassword_andReturnSignIn() async throws {
+        let signInResult = AuthSignInResult(nextStep: .resetPassword(nil))
+        authenticationService.mockedResetPasswordResult = AuthResetPasswordResult(
+            isPasswordReset: true,
+            nextStep: .done
+        )
+        let nextStep = try await state.nextStep(for: signInResult)
+        XCTAssertEqual(authenticationService.resetPasswordCount, 1)
+        guard case .signIn = nextStep else {
+            XCTFail("Expected next step to be signIn, was \(nextStep)")
+            return
+        }
+    }
+
+    func testNextStep_forSignIn_withResetPassword_andUnableToResetPassword_shouldReturnResetPassword() async throws {
+        let signInResult = AuthSignInResult(nextStep: .resetPassword(nil))
+        authenticationService.mockedResetPasswordResult = nil
+        let nextStep = try await state.nextStep(for: signInResult)
+        XCTAssertEqual(authenticationService.resetPasswordCount, 1)
+        guard case .resetPassword = nextStep else {
+            XCTFail("Expected next step to be resetPassword, was \(nextStep)")
+            return
+        }
+    }
+
+    func testNextStep_forSignUp_withConfirmSignUp_shouldReturnConfirmSignUp() async throws {
+        let destination = DeliveryDestination.email("email@email.com")
+        let result = AuthSignUpResult(.confirmUser(.init(destination: destination)))
+        let nextStep = try await state.nextStep(for: result)
+        guard case .confirmSignUp(let deliveryDetails) = nextStep else {
+            XCTFail("Expected next step to be confirmSignUp, was \(nextStep)")
+            return
+        }
+        XCTAssertNotNil(deliveryDetails)
+        XCTAssertEqual(deliveryDetails?.destination, destination)
+    }
+
+    func testNextStep_forSignUp_withDone_shouldCallSignIn_andReturnNextStep() async throws {
+        authenticationService.mockedSignInResult = AuthSignInResult(nextStep: .done)
+        authenticationService.mockedCurrentUser = MockAuthenticationService.User(
+            username: "username",
+            userId: "userId"
+        )
+
+        let signUpResult = AuthSignUpResult(.done)
+        let nextStep = try await state.nextStep(for: signUpResult)
+        guard case .signedIn(let user) = nextStep else {
+            XCTFail("Expected next step to be signedIn, was \(nextStep)")
+            return
+        }
+        XCTAssertEqual(user.username, "username")
+        XCTAssertEqual(user.userId, "userId")
+    }
+
+    func testNextStep_forSignUp_withDone_andUnableToSignIn_shouldReturnSignIn() async throws {
+        let result = AuthSignUpResult(.done)
+        let nextStep = try await state.nextStep(for: result)
+        guard case .signIn = nextStep else {
+            XCTFail("Expected next step to be signedIn, was \(nextStep)")
+            return
+        }
+    }
+
+    func testError_forNotAuthError_shouldReturnUnknownError() {
+        let error: Error = NSError(domain: "Authenticator", code: 100)
+        let authenticatorError = state.error(for: error)
+        XCTAssertEqual(authenticatorError.style, .error)
+        XCTAssertEqual(authenticatorError.content, "authenticator.unknownError".localized())
+    }
+
+    func testError_withNotAuthorizedError_shouldReturnLocalizedError() {
+        let authenticatorError = state.error(for: AuthError.notAuthorized("description", "recovery", nil))
+        XCTAssertEqual(authenticatorError.style, .error)
+        XCTAssertEqual(authenticatorError.content, "authenticator.authError.incorrectCredentials".localized())
+    }
+
+    func testError_withCustomErrorTransform_shouldReturnCustomError() {
+        var closureCount = 0
+        state.errorTransform = { error in
+            closureCount = 1
+            return .error(message: "A custom error")
+        }
+        let authenticatorError = state.error(for: AuthError.notAuthorized("description", "recovery", nil))
+        XCTAssertEqual(closureCount, 1)
+        XCTAssertEqual(authenticatorError.style, .error)
+        XCTAssertEqual(authenticatorError.content, "A custom error")
+    }
+
+    func testError_withLocalizedCognitoError_shouldReturnLocalizedError() {
+        let cognitoError = AWSCognitoAuthError.userNotFound
+        let authenticatorError = state.error(for: AuthError.service("description", "recovery", cognitoError))
+        XCTAssertEqual(authenticatorError.style, .error)
+        XCTAssertEqual(authenticatorError.content, "authenticator.cognitoError.userNotFound".localized())
+    }
+
+    func testError_withNotLocalizedCognitoError_shouldReturnUnknownError() {
+        let cognitoError = AWSCognitoAuthError.deviceNotTracked
+        let authenticatorError = state.error(for: AuthError.service("description", "recovery", cognitoError))
+        XCTAssertEqual(authenticatorError.style, .error)
+        XCTAssertEqual(authenticatorError.content, "authenticator.unknownError".localized())
+    }
+}
+

--- a/Tests/AuthenticatorTests/States/ConfirmResetPasswordStateTests.swift
+++ b/Tests/AuthenticatorTests/States/ConfirmResetPasswordStateTests.swift
@@ -1,0 +1,93 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+@testable import Authenticator
+import XCTest
+
+class ConfirmResetPasswordStateTests: XCTestCase {
+    private var state: ConfirmResetPasswordState!
+    private var authenticatorState: MockAuthenticatorState!
+    private var authenticationService: MockAuthenticationService!
+
+    override func setUp() {
+        state = ConfirmResetPasswordState(credentials: Credentials())
+        state.credentials.username = "username"
+        authenticatorState = MockAuthenticatorState()
+        authenticationService = MockAuthenticationService()
+        authenticatorState.authenticationService = authenticationService
+        state.configure(with: authenticatorState)
+    }
+
+    override func tearDown() {
+        state = nil
+        authenticatorState = nil
+        authenticationService = nil
+    }
+
+    func testConfirmResetPassword_withSuccess_andSignIn_shouldSetNextStep() async throws {
+        authenticationService.mockedSignInResult = .init(nextStep: .done)
+        authenticationService.mockedCurrentUser = MockAuthenticationService.User(
+            username: "username",
+            userId: "userId"
+        )
+
+        try await state.confirmResetPassword()
+        XCTAssertEqual(authenticationService.confirmResetPasswordCount, 1)
+        XCTAssertEqual(authenticatorState.setCurrentStepCount, 1)
+        let currentStep = try XCTUnwrap(authenticatorState.setCurrentStepValue)
+        guard case .signedIn(_) = currentStep else {
+            XCTFail("Expected signedIn, was \(currentStep)")
+            return
+        }
+    }
+
+    func testConfirmResetPassword_withError_shouldSetErrorMessage() async throws {
+        authenticationService.mockedConfirmResetPasswordError = .error(message: "Unable to confirm reset password")
+        do {
+            try await state.confirmResetPassword()
+            XCTFail("Should not succeed")
+        } catch {
+            guard let authenticatorError = error as? AuthenticatorError else {
+                XCTFail("Expected AuthenticatorError, was \(type(of: error))")
+                return
+            }
+
+            let task = Task { @MainActor in
+                XCTAssertNotNil(state.message)
+                XCTAssertEqual(state.message?.content, authenticatorError.content)
+            }
+            await task.value
+        }
+    }
+
+    func testConfirmResetPassword_withSuccess_andFailedToSignIn_shouldSetNextStep() async throws {
+        try await state.confirmResetPassword()
+        XCTAssertEqual(authenticationService.confirmResetPasswordCount, 1)
+        XCTAssertEqual(authenticatorState.setCurrentStepCount, 1)
+        let currentStep = try XCTUnwrap(authenticatorState.setCurrentStepValue)
+        guard case .signIn = currentStep else {
+            XCTFail("Expected signIn, was \(currentStep)")
+            return
+        }
+    }
+
+    func testDeliveryDetails_onConfirmResetPasswordStep_shouldReturnDetails() throws {
+        let destination = DeliveryDestination.sms("123456789")
+        authenticatorState.mockedStep = .confirmResetPassword(deliveryDetails: .init(destination: destination))
+
+        let deliveryDetails = try XCTUnwrap(state.deliveryDetails)
+        XCTAssertEqual(deliveryDetails.destination, destination)
+    }
+
+    func testDeliveryDetails_onUnexpectedStep_shouldRetunNil() throws {
+        let destination = DeliveryDestination.sms("123456789")
+        authenticatorState.mockedStep = .confirmSignUp(deliveryDetails: .init(destination: destination))
+
+        XCTAssertNil(state.deliveryDetails)
+    }
+}

--- a/Tests/AuthenticatorTests/States/ConfirmSignInWithCodeStateTests.swift
+++ b/Tests/AuthenticatorTests/States/ConfirmSignInWithCodeStateTests.swift
@@ -1,0 +1,100 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+@testable import Authenticator
+import XCTest
+
+class ConfirmSignInWithCodeStateTests: XCTestCase {
+    private var state: ConfirmSignInWithCodeState!
+    private var authenticatorState: MockAuthenticatorState!
+    private var authenticationService: MockAuthenticationService!
+
+    override func setUp() {
+        state = ConfirmSignInWithCodeState(credentials: Credentials())
+        authenticatorState = MockAuthenticatorState()
+        authenticationService = MockAuthenticationService()
+        authenticatorState.authenticationService = authenticationService
+        state.configure(with: authenticatorState)
+    }
+
+    override func tearDown() {
+        state = nil
+        authenticatorState = nil
+        authenticationService = nil
+    }
+
+    func testConfirmSignIn_withSuccess_shouldSetNextStep() async throws {
+        authenticationService.mockedConfirmSignInResult = .init(nextStep: .done)
+        authenticationService.mockedCurrentUser = MockAuthenticationService.User(
+            username: "username",
+            userId: "userId"
+        )
+
+        try await state.confirmSignIn()
+        XCTAssertEqual(authenticationService.confirmSignInCount, 1)
+        XCTAssertEqual(authenticatorState.setCurrentStepCount, 1)
+        let currentStep = try XCTUnwrap(authenticatorState.setCurrentStepValue)
+        guard case .signedIn(_) = currentStep else {
+            XCTFail("Expected signedIn, was \(currentStep)")
+            return
+        }
+    }
+
+    func testConfirmSignIn_withError_shouldSetErrorMessage() async throws {
+        do {
+            try await state.confirmSignIn()
+            XCTFail("Should not succeed")
+        } catch {
+            guard let authenticatorError = error as? AuthenticatorError else {
+                XCTFail("Expected AuthenticatorError, was \(type(of: error))")
+                return
+            }
+
+            let task = Task { @MainActor in
+                XCTAssertNotNil(state.message)
+                XCTAssertEqual(state.message?.content, authenticatorError.content)
+            }
+            await task.value
+        }
+    }
+
+    func testConfirmSignIn_withSuccess_andFailedToSignIn_shouldSetErrorMessage() async throws {
+        authenticationService.mockedConfirmSignInResult = .init(nextStep: .done)
+        do {
+            try await state.confirmSignIn()
+            XCTFail("Should not succeed")
+        } catch {
+            XCTAssertEqual(authenticationService.confirmSignInCount, 1)
+            guard let authenticatorError = error as? AuthenticatorError else {
+                XCTFail("Expected AuthenticatorError, was \(type(of: error))")
+                return
+            }
+
+            let task = Task { @MainActor in
+                XCTAssertNotNil(state.message)
+                XCTAssertEqual(state.message?.content, authenticatorError.content)
+            }
+            await task.value
+        }
+    }
+
+    func testDeliveryDetails_onConfirmSignInWithMFACodeStep_shouldReturnDetails() throws {
+        let destination = DeliveryDestination.sms("123456789")
+        authenticatorState.mockedStep = .confirmSignInWithMFACode(deliveryDetails: .init(destination: destination))
+
+        let deliveryDetails = try XCTUnwrap(state.deliveryDetails)
+        XCTAssertEqual(deliveryDetails.destination, destination)
+    }
+
+    func testDeliveryDetails_onUnexpectedStep_shouldReturnNil() throws {
+        let destination = DeliveryDestination.sms("123456789")
+        authenticatorState.mockedStep = .confirmSignUp(deliveryDetails: .init(destination: destination))
+
+        XCTAssertNil(state.deliveryDetails)
+    }
+}

--- a/Tests/AuthenticatorTests/States/ConfirmSignInWithNewPasswordStateTests.swift
+++ b/Tests/AuthenticatorTests/States/ConfirmSignInWithNewPasswordStateTests.swift
@@ -1,0 +1,85 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+@testable import Authenticator
+import XCTest
+
+class ConfirmSignInWithNewPasswordStateTests: XCTestCase {
+    private var state: ConfirmSignInWithNewPasswordState!
+    private var authenticatorState: MockAuthenticatorState!
+    private var authenticationService: MockAuthenticationService!
+
+    override func setUp() {
+        state = ConfirmSignInWithNewPasswordState(credentials: Credentials())
+        authenticatorState = MockAuthenticatorState()
+        authenticationService = MockAuthenticationService()
+        authenticatorState.authenticationService = authenticationService
+        state.configure(with: authenticatorState)
+    }
+
+    override func tearDown() {
+        state = nil
+        authenticatorState = nil
+        authenticationService = nil
+    }
+
+    func testConfirmSignIn_withSuccess_shouldSetNextStep() async throws {
+        authenticationService.mockedConfirmSignInResult = .init(nextStep: .done)
+        authenticationService.mockedCurrentUser = MockAuthenticationService.User(
+            username: "username",
+            userId: "userId"
+        )
+
+        try await state.confirmSignIn()
+        XCTAssertEqual(authenticationService.confirmSignInCount, 1)
+        XCTAssertEqual(authenticatorState.setCurrentStepCount, 1)
+        let currentStep = try XCTUnwrap(authenticatorState.setCurrentStepValue)
+        guard case .signedIn(_) = currentStep else {
+            XCTFail("Expected signedIn, was \(currentStep)")
+            return
+        }
+    }
+
+    func testConfirmSignIn_withError_shouldSetErrorMessage() async throws {
+        do {
+            try await state.confirmSignIn()
+            XCTFail("Should not succeed")
+        } catch {
+            guard let authenticatorError = error as? AuthenticatorError else {
+                XCTFail("Expected AuthenticatorError, was \(type(of: error))")
+                return
+            }
+
+            let task = Task { @MainActor in
+                XCTAssertNotNil(state.message)
+                XCTAssertEqual(state.message?.content, authenticatorError.content)
+            }
+            await task.value
+        }
+    }
+
+    func testConfirmSignIn_withSuccess_andFailedToSignIn_shouldSetErrorMessage() async throws {
+        authenticationService.mockedConfirmSignInResult = .init(nextStep: .done)
+        do {
+            try await state.confirmSignIn()
+            XCTFail("Should not succeed")
+        } catch {
+            XCTAssertEqual(authenticationService.confirmSignInCount, 1)
+            guard let authenticatorError = error as? AuthenticatorError else {
+                XCTFail("Expected AuthenticatorError, was \(type(of: error))")
+                return
+            }
+
+            let task = Task { @MainActor in
+                XCTAssertNotNil(state.message)
+                XCTAssertEqual(state.message?.content, authenticatorError.content)
+            }
+            await task.value
+        }
+    }
+}

--- a/Tests/AuthenticatorTests/States/ConfirmSignUpStateTests.swift
+++ b/Tests/AuthenticatorTests/States/ConfirmSignUpStateTests.swift
@@ -1,0 +1,138 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+@testable import Authenticator
+import XCTest
+
+class ConfirmSignUpStateTests: XCTestCase {
+    private var state: ConfirmSignUpState!
+    private var authenticatorState: MockAuthenticatorState!
+    private var authenticationService: MockAuthenticationService!
+
+    override func setUp() {
+        state = ConfirmSignUpState(credentials: Credentials())
+        authenticatorState = MockAuthenticatorState()
+        authenticationService = MockAuthenticationService()
+        authenticatorState.authenticationService = authenticationService
+        state.configure(with: authenticatorState)
+    }
+
+    override func tearDown() {
+        state = nil
+        authenticatorState = nil
+        authenticationService = nil
+    }
+
+    func testConfirmSignUp_withSuccess_shouldSignIn_andSetNextStep() async throws {
+        authenticationService.mockedConfirmSignUpResult = .init(.done)
+        authenticationService.mockedSignInResult = .init(nextStep: .done)
+        authenticationService.mockedCurrentUser = MockAuthenticationService.User(
+            username: "username",
+            userId: "userId"
+        )
+
+        try await state.confirmSignUp()
+        XCTAssertEqual(authenticationService.confirmSignUpCount, 1)
+        XCTAssertEqual(authenticationService.signInCount, 1)
+        XCTAssertEqual(authenticatorState.setCurrentStepCount, 1)
+        let currentStep = try XCTUnwrap(authenticatorState.setCurrentStepValue)
+        guard case .signedIn(_) = currentStep else {
+            XCTFail("Expected signedIn, was \(currentStep)")
+            return
+        }
+    }
+
+    func testConfirmSignUp_withError_shouldSetErrorMessage() async throws {
+        do {
+            try await state.confirmSignUp()
+            XCTFail("Should not succeed")
+        } catch {
+            guard let authenticatorError = error as? AuthenticatorError else {
+                XCTFail("Expected AuthenticatorError, was \(type(of: error))")
+                return
+            }
+
+            let task = Task { @MainActor in
+                XCTAssertNotNil(state.message)
+                XCTAssertEqual(state.message?.content, authenticatorError.content)
+            }
+            await task.value
+        }
+    }
+
+    func testConfirmSignUp_withSuccess_andFailedToSignIn_shouldSetNextStep() async throws {
+        authenticationService.mockedConfirmSignUpResult = .init(.done)
+
+        try await state.confirmSignUp()
+        XCTAssertEqual(authenticationService.confirmSignUpCount, 1)
+        XCTAssertEqual(authenticationService.signInCount, 1)
+        XCTAssertEqual(authenticatorState.setCurrentStepCount, 1)
+        let currentStep = try XCTUnwrap(authenticatorState.setCurrentStepValue)
+        guard case .signIn = currentStep else {
+            XCTFail("Expected signIn, was \(currentStep)")
+            return
+        }
+    }
+
+    func testSendCode_withSuccessAndDestination_shouldSetInfoMessage() async throws {
+        let destination = DeliveryDestination.email("email@email.com")
+        authenticationService.mockedResendSignUpCodeResult = .init(destination: destination)
+        try await state.sendCode()
+        let task = Task { @MainActor in
+            XCTAssertNotNil(state.message)
+            XCTAssertEqual(state.message?.style, .info)
+            XCTAssertEqual(state.message?.content, "authenticator.banner.sendCode".localized(using: destination.value!))
+        }
+        await task.value
+    }
+
+    func testSendCode_withSuccessWithoutDestination_shouldSetInfoMessage() async throws {
+        authenticationService.mockedResendSignUpCodeResult = .init(destination: .email(nil))
+        try await state.sendCode()
+        let task = Task { @MainActor in
+            XCTAssertNotNil(state.message)
+            XCTAssertEqual(state.message?.style, .info)
+            XCTAssertEqual(state.message?.content, "authenticator.banner.sendCodeGeneric".localized())
+        }
+        await task.value
+    }
+
+    func testSendCode_withFailure_shouldSetErrorMessage() async throws {
+        do {
+            try await state.sendCode()
+            XCTFail("Should not succeed")
+        } catch {
+            guard let authenticatorError = error as? AuthenticatorError else {
+                XCTFail("Expected AuthenticatorError, was \(type(of: error))")
+                return
+            }
+
+            let task = Task { @MainActor in
+                XCTAssertNotNil(state.message)
+                XCTAssertEqual(state.message?.style, .error)
+                XCTAssertEqual(state.message?.content, authenticatorError.content)
+            }
+            await task.value
+        }
+    }
+
+    func testDeliveryDetails_onConfirmSignUpStep_shouldReturnDetails() throws {
+        let destination = DeliveryDestination.sms("123456789")
+        authenticatorState.mockedStep = .confirmSignUp(deliveryDetails: .init(destination: destination))
+
+        let deliveryDetails = try XCTUnwrap(state.deliveryDetails)
+        XCTAssertEqual(deliveryDetails.destination, destination)
+    }
+
+    func testDeliveryDetails_onUnexpectedStep_shouldReturnNil() throws {
+        let destination = DeliveryDestination.sms("123456789")
+        authenticatorState.mockedStep = .confirmResetPassword(deliveryDetails: .init(destination: destination))
+
+        XCTAssertNil(state.deliveryDetails)
+    }
+}

--- a/Tests/AuthenticatorTests/States/ConfirmVerifyUserStateTests.swift
+++ b/Tests/AuthenticatorTests/States/ConfirmVerifyUserStateTests.swift
@@ -1,0 +1,120 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+@testable import Authenticator
+import XCTest
+
+class ConfirmVerifyUserStateTests: XCTestCase {
+    private var state: ConfirmVerifyUserState!
+    private var authenticatorState: MockAuthenticatorState!
+    private var authenticationService: MockAuthenticationService!
+
+    override func setUp() {
+        state = ConfirmVerifyUserState(credentials: Credentials())
+        authenticatorState = MockAuthenticatorState()
+        authenticatorState.mockedStep = .confirmVerifyUser(
+            attribute: .email,
+            deliveryDetails: nil
+        )
+        authenticationService = MockAuthenticationService()
+        authenticatorState.authenticationService = authenticationService
+        state.configure(with: authenticatorState)
+    }
+
+    override func tearDown() {
+        state = nil
+        authenticatorState = nil
+        authenticationService = nil
+    }
+
+    func testConfirmVerifyUser_withSuccess_andSignIn_shouldSetNextStep() async throws {
+        authenticationService.mockedCurrentUser = MockAuthenticationService.User(
+            username: "username",
+            userId: "userId"
+        )
+
+        try await state.confirmVerifyUser()
+        XCTAssertEqual(authenticationService.confirmUserAttributeCount, 1)
+        XCTAssertEqual(authenticatorState.setCurrentStepCount, 1)
+        let currentStep = try XCTUnwrap(authenticatorState.setCurrentStepValue)
+        guard case .signedIn(_) = currentStep else {
+            XCTFail("Expected signedIn, was \(currentStep)")
+            return
+        }
+    }
+
+    func testConfirmVerifyUser_withError_shouldSetErrorMessage() async throws {
+        authenticationService.mockedConfirmUserAttributeError = .error(message: "Unable to confirm attribute")
+        do {
+            try await state.confirmVerifyUser()
+            XCTFail("Should not succeed")
+        } catch {
+            guard let authenticatorError = error as? AuthenticatorError else {
+                XCTFail("Expected AuthenticatorError, was \(type(of: error))")
+                return
+            }
+
+            let task = Task { @MainActor in
+                XCTAssertNotNil(state.message)
+                XCTAssertEqual(state.message?.content, authenticatorError.content)
+            }
+            await task.value
+        }
+    }
+
+    func testSkip_withCurrentUser_shouldSetNextStep() async throws {
+        try await state.skip()
+        XCTAssertEqual(authenticatorState.setCurrentStepCount, 1)
+        let currentStep = try XCTUnwrap(authenticatorState.setCurrentStepValue)
+        guard case .signIn = currentStep else {
+            XCTFail("Expected signIn, was \(currentStep)")
+            return
+        }
+    }
+
+    func testSkip_withoutCurrentUser_shouldSetNextStep() async throws {
+        authenticationService.mockedCurrentUser = MockAuthenticationService.User(
+            username: "username",
+            userId: "userId"
+        )
+        try await state.skip()
+        XCTAssertEqual(authenticatorState.setCurrentStepCount, 1)
+        let currentStep = try XCTUnwrap(authenticatorState.setCurrentStepValue)
+        guard case .signedIn(_) = currentStep else {
+            XCTFail("Expected signedIn, was \(currentStep)")
+            return
+        }
+    }
+
+    func testDeliveryDetails_onConfirmVerifyUserStep_shouldReturnDetails() throws {
+        let destination = DeliveryDestination.sms("123456789")
+        authenticatorState.mockedStep = .confirmVerifyUser(attribute: .email, deliveryDetails: .init(destination: destination))
+
+        let deliveryDetails = try XCTUnwrap(state.deliveryDetails)
+        XCTAssertEqual(deliveryDetails.destination, destination)
+    }
+
+    func testDeliveryDetails_onUnexpectedStep_shouldReturnNil() throws {
+        let destination = DeliveryDestination.sms("123456789")
+        authenticatorState.mockedStep = .confirmSignUp(deliveryDetails: .init(destination: destination))
+
+        XCTAssertNil(state.deliveryDetails)
+    }
+
+    func testUserAttributeKey_onConfirmVerifyUserStep_shouldReturnAttributeKey() throws {
+        let attribute = AuthUserAttributeKey.phoneNumber
+        authenticatorState.mockedStep = .confirmVerifyUser(attribute: attribute, deliveryDetails: nil)
+        let userAttributeKey = try XCTUnwrap(state.userAttributeKey)
+        XCTAssertEqual(userAttributeKey, attribute)
+    }
+
+    func testUserAttributeKey_onUnexpectedStep_shouldReturnNil() throws {
+        authenticatorState.mockedStep = .resetPassword
+        XCTAssertNil(state.userAttributeKey)
+    }
+}

--- a/Tests/AuthenticatorTests/States/ResetPasswordStateTests.swift
+++ b/Tests/AuthenticatorTests/States/ResetPasswordStateTests.swift
@@ -1,0 +1,80 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+@testable import Authenticator
+import XCTest
+
+class ResetPasswordStateTests: XCTestCase {
+    private var state: ResetPasswordState!
+    private var authenticatorState: MockAuthenticatorState!
+    private var authenticationService: MockAuthenticationService!
+
+    override func setUp() {
+        state = ResetPasswordState(credentials: Credentials())
+        authenticatorState = MockAuthenticatorState()
+        authenticationService = MockAuthenticationService()
+        authenticatorState.authenticationService = authenticationService
+        state.configure(with: authenticatorState)
+    }
+
+    override func tearDown() {
+        state = nil
+        authenticatorState = nil
+        authenticationService = nil
+    }
+
+    func testResetPassword_withConfirmReset_shouldSetNextStep() async throws {
+        let destination = DeliveryDestination.sms("12345678")
+        authenticationService.mockedResetPasswordResult = .init(
+            isPasswordReset: false,
+            nextStep: .confirmResetPasswordWithCode(.init(destination: destination), nil)
+        )
+
+        try await state.resetPassword()
+        XCTAssertEqual(authenticatorState.setCurrentStepCount, 1)
+        let currentStep = try XCTUnwrap(authenticatorState.setCurrentStepValue)
+        guard case .confirmResetPassword(let deliveryDetails) = currentStep else {
+            XCTFail("Expected confirmResetPassword, was \(currentStep)")
+            return
+        }
+        XCTAssertEqual(deliveryDetails?.destination, destination)
+    }
+
+    func testResetPassword_withDone_shouldSetNextStep() async throws {
+        authenticationService.mockedResetPasswordResult = .init(
+            isPasswordReset: true,
+            nextStep: .done
+        )
+
+        try await state.resetPassword()
+        XCTAssertEqual(authenticatorState.setCurrentStepCount, 1)
+        let currentStep = try XCTUnwrap(authenticatorState.setCurrentStepValue)
+        guard case .signIn = currentStep else {
+            XCTFail("Expected signIn, was \(currentStep)")
+            return
+        }
+    }
+
+    func testResetPassword_withFailure_shouldSetErrorMessage() async throws {
+        do {
+            try await state.resetPassword()
+            XCTFail("Should not succeed")
+        } catch {
+            guard let authenticatorError = error as? AuthenticatorError else {
+                XCTFail("Expected AuthenticatorError, was \(type(of: error))")
+                return
+            }
+
+            let task = Task { @MainActor in
+                XCTAssertNotNil(state.message)
+                XCTAssertEqual(state.message?.content, authenticatorError.content)
+            }
+            await task.value
+        }
+    }
+}

--- a/Tests/AuthenticatorTests/States/SignInStateTests.swift
+++ b/Tests/AuthenticatorTests/States/SignInStateTests.swift
@@ -1,0 +1,64 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+@testable import Authenticator
+import XCTest
+
+class SignInStateTests: XCTestCase {
+    private var state: SignInState!
+    private var authenticatorState: MockAuthenticatorState!
+    private var authenticationService: MockAuthenticationService!
+
+    override func setUp() {
+        state = SignInState(credentials: Credentials())
+        authenticatorState = MockAuthenticatorState()
+        authenticationService = MockAuthenticationService()
+        authenticatorState.authenticationService = authenticationService
+        state.configure(with: authenticatorState)
+    }
+
+    override func tearDown() {
+        state = nil
+        authenticatorState = nil
+        authenticationService = nil
+    }
+
+    func testSignIn_withValidCredentials_shouldSetNextStep() async throws {
+        authenticationService.mockedSignInResult = .init(nextStep: .done)
+        authenticationService.mockedCurrentUser = MockAuthenticationService.User(
+            username: "username",
+            userId: "userId"
+        )
+
+        try await state.signIn()
+        XCTAssertEqual(authenticatorState.setCurrentStepCount, 1)
+        let currentStep = try XCTUnwrap(authenticatorState.setCurrentStepValue)
+        guard case .signedIn(_) = currentStep else {
+            XCTFail("Expected signedIn, was \(currentStep)")
+            return
+        }
+    }
+
+    func testSignIn_withInvalidCredentials_shouldSetErrorMessage() async throws {
+        do {
+            try await state.signIn()
+            XCTFail("Should not succeed")
+        } catch {
+            guard let authenticatorError = error as? AuthenticatorError else {
+                XCTFail("Expected AuthenticatorError, was \(type(of: error))")
+                return
+            }
+
+            let task = Task { @MainActor in
+                XCTAssertNotNil(state.message)
+                XCTAssertEqual(state.message?.content, authenticatorError.content)
+            }
+            await task.value
+        }
+    }
+}

--- a/Tests/AuthenticatorTests/States/SignUpStateTests.swift
+++ b/Tests/AuthenticatorTests/States/SignUpStateTests.swift
@@ -1,0 +1,137 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+@testable import Authenticator
+import XCTest
+
+class SignUpStateTests: XCTestCase {
+    private var state: SignUpState!
+    private var authenticatorState: MockAuthenticatorState!
+    private var authenticationService: MockAuthenticationService!
+
+    override func setUp() {
+        state = SignUpState(credentials: Credentials())
+        authenticatorState = MockAuthenticatorState()
+        authenticationService = MockAuthenticationService()
+        authenticatorState.authenticationService = authenticationService
+        state.configure(with: authenticatorState)
+    }
+
+    override func tearDown() {
+        state = nil
+        authenticatorState = nil
+        authenticationService = nil
+    }
+
+    func testSignUp_withSuccess_shouldSetNextStep() async throws {
+        authenticationService.mockedSignUpResult = .init(.done)
+        authenticationService.mockedSignInResult = .init(nextStep: .done)
+        authenticationService.mockedCurrentUser = MockAuthenticationService.User(
+            username: "username",
+            userId: "userId"
+        )
+
+        try await state.signUp()
+        XCTAssertEqual(authenticatorState.setCurrentStepCount, 1)
+        let currentStep = try XCTUnwrap(authenticatorState.setCurrentStepValue)
+        guard case .signedIn(_) = currentStep else {
+            XCTFail("Expected signedIn, was \(currentStep)")
+            return
+        }
+    }
+
+    func testSignUp_withFailure_shouldSetErrorMessage() async throws {
+        do {
+            try await state.signUp()
+            XCTFail("Should not succeed")
+        } catch {
+            guard let authenticatorError = error as? AuthenticatorError else {
+                XCTFail("Expected AuthenticatorError, was \(type(of: error))")
+                return
+            }
+
+            let task = Task { @MainActor in
+                XCTAssertNotNil(state.message)
+                XCTAssertEqual(state.message?.content, authenticatorError.content)
+            }
+            await task.value
+        }
+    }
+
+    func testConfigure_withFields_shouldPopulateFields_addingVerificationMechanism() {
+        authenticatorState.configuration.verificationMechanisms = [
+            .email,
+            .phoneNumber
+        ]
+        state.configure(with: [
+            .username(),
+            .password()
+        ])
+
+        XCTAssertEqual(state.fields.count, 4) // 2 verification + 2 provided
+        XCTAssertTrue(state.fields.allSatisfy({ field in
+            field.field.attributeType == .username ||
+            field.field.attributeType == .password ||
+            (field.field.attributeType == .phoneNumber && field.field.isRequired) ||
+            (field.field.attributeType == .email && field.field.isRequired)
+        }))
+    }
+
+    func testConfigure_withFields_shouldPopulateFields_addingMarkVerificationMechanismAsRequired() {
+        authenticatorState.configuration.verificationMechanisms = [
+            .email,
+        ]
+        state.configure(with: [
+            .username(),
+            .password(),
+            .email(isRequired: false)
+        ])
+
+        XCTAssertEqual(state.fields.count, 3)
+        XCTAssertTrue(state.fields.contains(where: { field in
+            field.field.attributeType == .email && field.field.isRequired
+        }))
+    }
+
+    func testConfigure_withEmptyFields_shouldReadFromConfiguration() {
+        authenticatorState.configuration.signupAttributes = [
+            .address,
+            .nickname
+        ]
+        authenticatorState.configuration.verificationMechanisms = [
+            .phoneNumber
+        ]
+        state.configure(with: [])
+        XCTAssertEqual(state.fields.count, 6) // username, password, confirm password by default + 3 from configuration
+        XCTAssertTrue(state.fields.allSatisfy({ field in
+            field.field.attributeType == .username ||
+            field.field.attributeType == .password ||
+            field.field.attributeType == .passwordConfirmation ||
+            field.field.attributeType == .address ||
+            field.field.attributeType == .nickname ||
+            (field.field.attributeType == .phoneNumber && field.field.isRequired)
+        }))
+    }
+
+    func testConfigure_withEmptyFields_usingEmailLogin_shouldReadFromConfiguration() {
+        authenticatorState.configuration.usernameAttributes = [
+            .email
+        ]
+        authenticatorState.configuration.verificationMechanisms = [
+            .phoneNumber
+        ]
+        state.configure(with: [])
+        XCTAssertEqual(state.fields.count, 4) // email, password, confirm password by default + 1 from configuration
+        XCTAssertTrue(state.fields.allSatisfy({ field in
+            field.field.attributeType == .email ||
+            field.field.attributeType == .password ||
+            field.field.attributeType == .passwordConfirmation ||
+            (field.field.attributeType == .phoneNumber && field.field.isRequired)
+        }))
+    }
+}

--- a/Tests/AuthenticatorTests/States/SignedInStateTests.swift
+++ b/Tests/AuthenticatorTests/States/SignedInStateTests.swift
@@ -1,0 +1,34 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+@testable import Authenticator
+import XCTest
+
+class SignedInStateTests: XCTestCase {
+    private var state: SignedInState!
+    private var authenticationService: MockAuthenticationService!
+
+    override func setUp() {
+        authenticationService = MockAuthenticationService()
+        state = SignedInState(
+            user: MockAuthenticationService.User(username: "username", userId: "userId"),
+            authenticationService: authenticationService
+        )
+    }
+
+    override func tearDown() {
+        state = nil
+        authenticationService = nil
+    }
+
+    func testSignOut() async {
+        let result = await state.signOut()
+        XCTAssertEqual(authenticationService.signOutCount, 1)
+        XCTAssertTrue(result is MockAuthenticationService.SignOutResult)
+    }
+}

--- a/Tests/AuthenticatorTests/States/VerifyUserStateTests.swift
+++ b/Tests/AuthenticatorTests/States/VerifyUserStateTests.swift
@@ -1,0 +1,116 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+@testable import Authenticator
+import XCTest
+
+class VerifyUserStateTests: XCTestCase {
+    private var state: VerifyUserState!
+    private var authenticatorState: MockAuthenticatorState!
+    private var authenticationService: MockAuthenticationService!
+
+    override func setUp() {
+        state = VerifyUserState(credentials: Credentials())
+        authenticatorState = MockAuthenticatorState()
+        authenticatorState.mockedStep = .confirmVerifyUser(
+            attribute: .email,
+            deliveryDetails: nil
+        )
+        authenticationService = MockAuthenticationService()
+        authenticatorState.authenticationService = authenticationService
+        state.configure(with: authenticatorState)
+    }
+
+    override func tearDown() {
+        state = nil
+        authenticatorState = nil
+        authenticationService = nil
+    }
+
+    func testVerifyUser_withSuccess_shouldSetNextStep() async throws {
+        let destination = DeliveryDestination.email("email@email.com")
+        authenticationService.mockedResendConfirmationCodeForAttributeResult = .init(destination: destination)
+        let task = Task { @MainActor in
+            state.selectedField = .email
+        }
+        await task.value
+        try await state.verifyUser()
+        XCTAssertEqual(authenticationService.resendConfirmationCodeForAttributeCount, 1)
+        XCTAssertEqual(authenticatorState.setCurrentStepCount, 1)
+        let currentStep = try XCTUnwrap(authenticatorState.setCurrentStepValue)
+        guard case .confirmVerifyUser(let attribute, let deliveryDetails) = currentStep else {
+            XCTFail("Expected confirmVerifyUser, was \(currentStep)")
+            return
+        }
+
+        XCTAssertEqual(attribute, .email)
+        XCTAssertEqual(deliveryDetails?.destination, destination)
+    }
+
+    func testVerifyUser_withError_shouldSetErrorMessage() async throws {
+        let task = Task { @MainActor in
+            state.selectedField = .email
+        }
+        await task.value
+        do {
+            try await state.verifyUser()
+            XCTFail("Should not succeed")
+        } catch {
+            guard let authenticatorError = error as? AuthenticatorError else {
+                XCTFail("Expected AuthenticatorError, was \(type(of: error))")
+                return
+            }
+
+            let task = Task { @MainActor in
+                XCTAssertNotNil(state.message)
+                XCTAssertEqual(state.message?.content, authenticatorError.content)
+            }
+            await task.value
+        }
+    }
+
+    func testSkip_withCurrentUser_shouldSetNextStep() async throws {
+        try await state.skip()
+        XCTAssertEqual(authenticatorState.setCurrentStepCount, 1)
+        let currentStep = try XCTUnwrap(authenticatorState.setCurrentStepValue)
+        guard case .signIn = currentStep else {
+            XCTFail("Expected signIn, was \(currentStep)")
+            return
+        }
+    }
+
+    func testSkip_withoutCurrentUser_shouldSetNextStep() async throws {
+        authenticationService.mockedCurrentUser = MockAuthenticationService.User(
+            username: "username",
+            userId: "userId"
+        )
+        try await state.skip()
+        XCTAssertEqual(authenticatorState.setCurrentStepCount, 1)
+        let currentStep = try XCTUnwrap(authenticatorState.setCurrentStepValue)
+        guard case .signedIn(_) = currentStep else {
+            XCTFail("Expected signedIn, was \(currentStep)")
+            return
+        }
+    }
+
+
+    func testUnverifiedFields_onConfirmVerifyUserStep_shouldReturnAttributeKey() throws {
+        let attributes: [AuthUserAttributeKey] = [
+            .phoneNumber,
+            .email
+        ]
+        authenticatorState.mockedStep = .verifyUser(attributes: attributes)
+        let unverifiedFields = try XCTUnwrap(state.unverifiedFields)
+        XCTAssertEqual(unverifiedFields, attributes)
+    }
+
+    func testUnverifiedFields_onUnexpectedStep_shouldReturnEmpty() throws {
+        authenticatorState.mockedStep = .signIn
+        XCTAssertTrue(state.unverifiedFields.isEmpty)
+    }
+}


### PR DESCRIPTION
**Description of changes:**

This PR adds unit tests for all the Authenticator States, which are the ones responsible of all the business logic.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
