### PR TITLE
feat: Adding macOS support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "AmplifyUIAuthenticator",
     defaultLocalization: "en",
-    platforms: [.iOS(.v15)],
+    platforms: [.iOS(.v15), .macOS(.v12)],
     products: [
         .library(
             name: "Authenticator",

--- a/Sources/Authenticator/Extensions/Color+Utils.swift
+++ b/Sources/Authenticator/Extensions/Color+Utils.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 extension Color {
+    /// Creates a color using HSL (Hue, Saturation, and Lightness)
     init(hue: Int, saturation: Int, lightness: Int) {
         let hue = Double(hue) / 360.0
         let saturation = Double(saturation) / 100.0
@@ -23,7 +24,9 @@ extension Color {
         )
     }
 
+    /// Creates a color that suports Light and Dark mode
     init(light: Color, dark: Color) {
+    #if os(iOS)
         self.init(
             uiColor: .init {
                 if $0.userInterfaceStyle == .dark {
@@ -33,5 +36,16 @@ extension Color {
                 }
             }
         )
+    #elseif os(macOS)
+        self.init(
+            nsColor: .init(name: nil) {
+                if $0.name == .darkAqua {
+                    return NSColor(dark)
+                } else {
+                    return NSColor(light)
+                }
+            }
+        )
+    #endif
     }
 }

--- a/Sources/Authenticator/Models/SignUpAttribute.swift
+++ b/Sources/Authenticator/Models/SignUpAttribute.swift
@@ -6,8 +6,14 @@
 //
 
 import Amplify
+#if canImport(AppKit)
+import AppKit
+#endif
 import Foundation
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 /// Represents to which Sign Up attribute a field is associated with.
 public enum SignUpAttribute: Equatable, Hashable {
@@ -27,9 +33,9 @@ public enum SignUpAttribute: Equatable, Hashable {
     case preferredUsername
     case profile
     case website
-#if canImport(UIKit)
+#if os(iOS)
     case custom(attributeKey: AuthUserAttributeKey, textContentType: UITextContentType? = nil)
-#else
+#elseif os(macOS)
     case custom(attributeKey: AuthUserAttributeKey, textContentType: NSTextContentType? = nil)
 #endif
 
@@ -67,17 +73,12 @@ public enum SignUpAttribute: Equatable, Hashable {
             return .profile
         case .website:
             return .website
-#if canImport(UIKit)
         case .custom(let attributeKey, _):
             return attributeKey
-#else
-        case .custom(let attributeKey, _):
-            return attributeKey
-#endif
         }
     }
 
-#if canImport(UIKit)
+#if os(iOS)
     var keyboardType: UIKeyboardType {
         switch self {
         case .email:

--- a/Sources/Authenticator/Models/SignUpAttribute.swift
+++ b/Sources/Authenticator/Models/SignUpAttribute.swift
@@ -30,7 +30,7 @@ public enum SignUpAttribute: Equatable, Hashable {
 #if canImport(UIKit)
     case custom(attributeKey: AuthUserAttributeKey, textContentType: UITextContentType? = nil)
 #else
-    case custom(attributeKey: AuthUserAttributeKey)
+    case custom(attributeKey: AuthUserAttributeKey, textContentType: NSTextContentType? = nil)
 #endif
 
     var attributeKey: AuthUserAttributeKey? {
@@ -71,7 +71,7 @@ public enum SignUpAttribute: Equatable, Hashable {
         case .custom(let attributeKey, _):
             return attributeKey
 #else
-        case .custom(let attributeKey):
+        case .custom(let attributeKey, _):
             return attributeKey
 #endif
         }
@@ -122,17 +122,26 @@ public enum SignUpAttribute: Equatable, Hashable {
             return nil
         case .website:
             return .URL
-#if canImport(UIKit)
         case .custom(_, let textContentType):
             return textContentType
-#else
-        case .custom(_):
+        }
+    }
+#elseif os(macOS)
+    var textContentType: NSTextContentType? {
+        switch self {
+        case .username,
+             .preferredUsername:
+            return .username
+        case .password,
+             .passwordConfirmation:
+            return .password
+        case .custom(_, let textContentType):
+            return textContentType
+        default:
             return nil
-#endif
         }
     }
 #endif
-
 }
 
 extension CognitoConfiguration.VerificationMechanism {

--- a/Sources/Authenticator/Theming/AuthenticatorTheme.swift
+++ b/Sources/Authenticator/Theming/AuthenticatorTheme.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import UIKit
 
 public class AuthenticatorTheme: ObservableObject {
     public struct Spacing {
@@ -40,7 +39,7 @@ public class AuthenticatorTheme: ObservableObject {
         init() {}
         public var spacing = Spacing (
             horizontal: 5,
-            vertical: 20
+            vertical: Platform.isMacOS ? 15 : 20
         )
         public var style = Style(
             cornerRadius: 0,
@@ -70,12 +69,12 @@ public class AuthenticatorTheme: ObservableObject {
         }
 
         public var primary = Size(
-            font: .body.bold(),
+            font: Platform.isMacOS ? .title3.bold() : .body.bold(),
             cornerRadius: 5,
             padding: 13
         )
         public var link = Size(
-            font: .system(size: 15, weight: .semibold),
+            font: Platform.isMacOS ? .body.weight(.semibold) : .subheadline.weight(.semibold),
             cornerRadius: 0,
             padding: 10
         )
@@ -84,14 +83,14 @@ public class AuthenticatorTheme: ObservableObject {
     public struct Field {
         init() {}
         public var spacing = Spacing(
-            horizontal: 0,
+            horizontal: Platform.isMacOS ? 5 : 0,
             vertical: 5
         )
         public var style = Style(
             cornerRadius: 5,
             padding: 10,
             borderWidth: 1,
-            backgroundColor: .clear
+            backgroundColor: Platform.isMacOS ? .AmplifyUI.Background.primary : .clear
         )
     }
 

--- a/Sources/Authenticator/Utilities/AuthenticatorField.swift
+++ b/Sources/Authenticator/Utilities/AuthenticatorField.swift
@@ -39,8 +39,6 @@ struct AuthenticatorField<Content: View>: View {
             }
 
             content
-
-        #if os(iOS)
             .background(
                 RoundedRectangle(cornerRadius: theme.Fields.style.cornerRadius, style: .continuous)
                     .fill(backgroundColor)
@@ -51,7 +49,6 @@ struct AuthenticatorField<Content: View>: View {
                             lineWidth: borderWidth)
 
             )
-        #endif
 
             if let errorMessage = errorMessage {
                 SwiftUI.Text(errorMessage)
@@ -69,7 +66,7 @@ struct AuthenticatorField<Content: View>: View {
 
     private var backgroundColor: Color {
         isEnabled ? theme.Fields.style.backgroundColor : Color(
-            light: Color(uiColor: .systemGray6),
+            light: theme.Colors.Background.disabled,
             dark: .clear
         )
     }
@@ -98,6 +95,7 @@ struct AuthenticatorField<Content: View>: View {
         let width = theme.Fields.style.borderWidth
         return isFocused ? width + 1 : width
     }
+
     private var title: String {
         return label ?? placeholder
     }

--- a/Sources/Authenticator/Utilities/CountryUtils.swift
+++ b/Sources/Authenticator/Utilities/CountryUtils.swift
@@ -27,7 +27,7 @@ struct Country: Equatable, Hashable {
 
 extension Locale {
     var countryCode: String {
-        if #available(iOS 16, *) {
+        if #available(iOS 16, macOS 13, *) {
             return region?.identifier ?? ""
         } else {
             return regionCode ?? ""

--- a/Sources/Authenticator/Utilities/Platform.swift
+++ b/Sources/Authenticator/Utilities/Platform.swift
@@ -1,0 +1,32 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+enum Platform {
+    case macOS
+    case iOS
+    case unsupported
+
+    static var current: Platform {
+    #if os(macOS)
+        return .macOS
+    #elseif os(iOS)
+        return .iOS
+    #else
+        return .unsupported
+    #endif
+    }
+
+    static var isMacOS: Bool {
+        current == .macOS
+    }
+
+    static var isIOS: Bool {
+        current == .iOS
+    }
+}

--- a/Sources/Authenticator/Views/ConfirmResetPasswordView.swift
+++ b/Sources/Authenticator/Views/ConfirmResetPasswordView.swift
@@ -73,8 +73,10 @@ public struct ConfirmResetPasswordView<Header: View,
                 validator: codeValidator
             )
             .focused(focusedField.projectedValue, equals: .confirmationCode)
-            .keyboardType(.default)
             .textContentType(.oneTimeCode)
+        #if os(iOS)
+            .keyboardType(.default)
+        #endif
 
             PasswordField(
                 "authenticator.field.newPassword.label".localized(),
@@ -83,8 +85,12 @@ public struct ConfirmResetPasswordView<Header: View,
                 validator: passwordValidator
             )
             .focused(focusedField.projectedValue, equals: .newPassword)
+        #if os(iOS)
             .textContentType(.newPassword)
             .textInputAutocapitalization(.never)
+        #elseif os(macOS)
+            .textContentType(.password)
+        #endif
 
             PasswordField(
                 "authenticator.field.confirmPassword.label".localized(),
@@ -93,8 +99,12 @@ public struct ConfirmResetPasswordView<Header: View,
                 validator: confirmPasswordValidator
             )
             .focused(focusedField.projectedValue, equals: .newPasswordConfirmation)
+        #if os(iOS)
             .textContentType(.newPassword)
             .textInputAutocapitalization(.never)
+        #elseif os(macOS)
+            .textContentType(.password)
+        #endif
 
             Button("authenticator.confirmResetPassword.button.submit".localized()) {
                 Task {
@@ -111,6 +121,15 @@ public struct ConfirmResetPasswordView<Header: View,
             state.message = .info(
                 message: state.localizedMessage(for: state.deliveryDetails)
             )
+        }
+        .onSubmit {
+            if hasNextField {
+                focusNextField()
+            } else {
+                Task {
+                    await confirmResetPassword()
+                }
+            }
         }
     }
 

--- a/Sources/Authenticator/Views/ConfirmSignInWithNewPasswordView.swift
+++ b/Sources/Authenticator/Views/ConfirmSignInWithNewPasswordView.swift
@@ -71,7 +71,9 @@ public struct ConfirmSignInWithNewPasswordView<Header: View,
             )
             .focused(focusedField.projectedValue, equals: .newPassword)
             .textContentType(.password)
+        #if os(iOS)
             .textInputAutocapitalization(.never)
+        #endif
 
             PasswordField(
                 "authenticator.field.confirmPassword.label".localized(),
@@ -81,7 +83,9 @@ public struct ConfirmSignInWithNewPasswordView<Header: View,
             )
             .focused(focusedField.projectedValue, equals: .newPasswordConfirmation)
             .textContentType(.password)
+        #if os(iOS)
             .textInputAutocapitalization(.never)
+        #endif
 
             Button("authenticator.confirmSignInWithNewPassword.button.submit".localized()) {
                 Task {
@@ -94,6 +98,15 @@ public struct ConfirmSignInWithNewPasswordView<Header: View,
         }
         .messageBanner($state.message)
         .keyboardIterableToolbar(fields: self)
+        .onSubmit {
+            if hasNextField {
+                focusNextField()
+            } else {
+                Task {
+                    await confirmSignIn()
+                }
+            }
+        }
     }
 
     /// Sets a custom error mapping function for the `AuthError`s that are displayed

--- a/Sources/Authenticator/Views/ConfirmSignUpView.swift
+++ b/Sources/Authenticator/Views/ConfirmSignUpView.swift
@@ -56,8 +56,10 @@ public struct ConfirmSignUpView<Header: View,
                 placeholder: "authenticator.field.code.placeholder".localized(),
                 validator: codeValidator
             )
-            .keyboardType(.default)
             .textContentType(.oneTimeCode)
+        #if os(iOS)
+            .keyboardType(.default)
+        #endif
 
             HStack(alignment: .center) {
                 Text("authenticator.confirmSignUp.lostCode".localized())
@@ -86,6 +88,11 @@ public struct ConfirmSignUpView<Header: View,
             state.message = .info(
                 message: state.localizedMessage(for: state.deliveryDetails)
             )
+        }
+        .onSubmit {
+            Task {
+                await confirmSignUp()
+            }
         }
     }
 

--- a/Sources/Authenticator/Views/ConfirmVerifyUserView.swift
+++ b/Sources/Authenticator/Views/ConfirmVerifyUserView.swift
@@ -51,8 +51,10 @@ public struct ConfirmVerifyUserView<Header: View,
                 validator: codeValidator
 
             )
-            .keyboardType(.default)
             .textContentType(.oneTimeCode)
+        #if os(iOS)
+            .keyboardType(.default)
+        #endif
 
             Button("authenticator.confirmVerifyUser.button.verify".localized()) {
                 Task {
@@ -71,6 +73,11 @@ public struct ConfirmVerifyUserView<Header: View,
             footerContent
         }
         .messageBanner($state.message)
+        .onSubmit {
+            Task {
+                await confirmVerifyUser()
+            }
+        }
     }
 
     /// Sets a custom error mapping function for the `AuthError`s that are displayed

--- a/Sources/Authenticator/Views/Internal/ConfirmSignInWithCodeView.swift
+++ b/Sources/Authenticator/Views/Internal/ConfirmSignInWithCodeView.swift
@@ -44,8 +44,10 @@ struct ConfirmSignInWithCodeView<Header: View,
                 placeholder: "authenticator.field.code.placeholder".localized(),
                 validator: codeValidator
             )
-            .keyboardType(.default)
             .textContentType(.oneTimeCode)
+        #if os(iOS)
+            .keyboardType(.default)
+        #endif
 
             Button("authenticator.confirmSignInWithCode.button.submit".localized()) {
                 Task { await confirmSignIn() }
@@ -55,6 +57,11 @@ struct ConfirmSignInWithCodeView<Header: View,
             footerContent
         }
         .messageBanner($state.message)
+        .onSubmit {
+            Task {
+                await confirmSignIn()
+            }
+        }
     }
 
     private func confirmSignIn() async {

--- a/Sources/Authenticator/Views/Internal/SignUpInputField.swift
+++ b/Sources/Authenticator/Views/Internal/SignUpInputField.swift
@@ -64,7 +64,9 @@ struct SignUpInputField: View {
             }
         }
         .textContentType(field.attributeType.textContentType)
+    #if os(iOS)
         .keyboardType(field.attributeType.keyboardType)
+    #endif
     }
 
     @ViewBuilder func customView(for field: CustomSignUpField) -> some View {

--- a/Sources/Authenticator/Views/Primitives/Button.swift
+++ b/Sources/Authenticator/Views/Primitives/Button.swift
@@ -23,24 +23,8 @@ struct Button: View {
     }
 
     var body: some View {
-        SwiftUI.Button(action: action) {
-            Text(label)
-                .font(font)
-                .foregroundColor(foregroundColor)
-                .padding(.all, padding)
-                .frame(maxWidth: viewModifiers.frame.maxWidth)
-                .background(
-                    RoundedRectangle(cornerRadius: cornerRadius)
-                        .stroke(
-                            borderColor,
-                            lineWidth: borderWidth
-                        )
-                        .background(
-                            backgroundColor
-                                .cornerRadius(cornerRadius)
-                        )
-                )
-        }
+        SwiftUI.Button(label, action: action)
+            .buttonStyle(buttonStyle)
     }
 
     private var backgroundColor: Color {
@@ -115,6 +99,17 @@ struct Button: View {
             return theme.Authenticator.style.padding
         }
     }
+
+    private var buttonStyle: some ButtonStyle {
+        return AuthenticatorButtonStyle(
+            font: font,
+            foregroundColor: foregroundColor,
+            backgroundColor: backgroundColor,
+            cornerRadius: cornerRadius,
+            padding: padding,
+            maxWidth: viewModifiers.frame.maxWidth
+        )
+    }
 }
 
 extension Button {
@@ -168,5 +163,25 @@ extension Button {
         var view = self
         view.viewModifiers.style = buttonStyle
         return view
+    }
+}
+
+private struct AuthenticatorButtonStyle: ButtonStyle {
+    let font: Font
+    let foregroundColor: Color
+    let backgroundColor: Color
+    let cornerRadius: CGFloat
+    let padding: CGFloat?
+    let maxWidth: CGFloat?
+
+    func makeBody(configuration: Self.Configuration) -> some View {
+        configuration.label
+            .font(font)
+            .padding(.all, padding)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: maxWidth)
+            .foregroundColor(configuration.isPressed ? foregroundColor.opacity(0.5) : foregroundColor)
+            .background(configuration.isPressed ? backgroundColor.opacity(0.5) : backgroundColor)
+            .cornerRadius(cornerRadius)
     }
 }

--- a/Sources/Authenticator/Views/Primitives/DatePicker.swift
+++ b/Sources/Authenticator/Views/Primitives/DatePicker.swift
@@ -113,7 +113,7 @@ struct DatePicker: View {
 
     private var backgroundColor: Color {
         isEnabled ? .clear : Color(
-            light: Color(uiColor: .systemGray6),
+            light: theme.Colors.Background.disabled,
             dark: .clear
         )
     }

--- a/Sources/Authenticator/Views/Primitives/ImageButton.swift
+++ b/Sources/Authenticator/Views/Primitives/ImageButton.swift
@@ -30,6 +30,7 @@ struct ImageButton: View {
                 SwiftUI.Image(systemName: image.rawValue)
             }
         )
+        .buttonStyle(.plain)
         .foregroundColor(color)
         .accessibilityLabel(
             Text(accessibilityLabel)

--- a/Sources/Authenticator/Views/Primitives/PasswordField.swift
+++ b/Sources/Authenticator/Views/Primitives/PasswordField.swift
@@ -64,12 +64,14 @@ struct PasswordField: View {
                             validator.validate()
                         }
                     }
+                    .textFieldStyle(.plain)
+                    .frame(height: Platform.isMacOS ? 20 : 25)
+                    .padding([.top, .bottom, .leading], theme.Fields.style.padding)
                 #if os(iOS)
                     .autocapitalization(.none)
-                    .frame(height: 25)
-                    .padding([.top, .bottom, .leading], theme.Fields.style.padding)
                 #endif
-                if focusedField != nil, !text.isEmpty {
+
+                if shouldDisplayShowPasswordButton {
                     ImageButton(showPasswordImage) {
                         isShowingPassword.toggle()
                         focusedField = isShowingPassword ? .plain : .secure
@@ -99,7 +101,8 @@ struct PasswordField: View {
     private var showPasswordButtonColor: Color {
         switch validator.state {
         case .normal:
-            return theme.Colors.Border.interactive
+            return isFocused ?
+                theme.Colors.Border.interactive : theme.Colors.Border.primary
         case .error:
             return theme.Colors.Border.error
         }
@@ -107,6 +110,12 @@ struct PasswordField: View {
 
     private var showPasswordImage: ImageButton.Image {
         return isShowingPassword ? .showPassword : .hidePassword
+    }
+
+    private var shouldDisplayShowPasswordButton: Bool {
+        // Show the show password button when there's text and
+        // the field is focused on non-macOS platforms
+        return !text.isEmpty && (Platform.isMacOS || focusedField != nil)
     }
 
     private enum FieldType: Hashable {

--- a/Sources/Authenticator/Views/Primitives/TextField.swift
+++ b/Sources/Authenticator/Views/Primitives/TextField.swift
@@ -64,14 +64,14 @@ struct TextField: View {
                             validator.validate()
                         }
                     }
-
+                    .textFieldStyle(.plain)
+                    .frame(height: Platform.isMacOS ? 20 : 25)
+                    .padding([.top, .bottom, .leading], theme.Fields.style.padding)
                 #if os(iOS)
                     .autocapitalization(.none)
-                    .frame(height: 25)
-                    .padding([.top, .bottom, .leading], theme.Fields.style.padding)
                 #endif
 
-                if isFocused, !text.isEmpty {
+                if shouldDisplayClearButton {
                     ImageButton(.clear) {
                         text = ""
                     }
@@ -85,9 +85,16 @@ struct TextField: View {
     private var clearButtonColor: Color {
         switch validator.state {
         case .normal:
-            return theme.Colors.Border.interactive
+            return isFocused ?
+                theme.Colors.Border.interactive : theme.Colors.Border.primary
         case .error:
             return theme.Colors.Border.error
         }
+    }
+
+    private var shouldDisplayClearButton: Bool {
+        // Show the clear button when there's text and
+        // the field is focused on non-macOS platforms
+        return !text.isEmpty && (Platform.isMacOS || isFocused)
     }
 }

--- a/Sources/Authenticator/Views/ResetPasswordView.swift
+++ b/Sources/Authenticator/Views/ResetPasswordView.swift
@@ -52,8 +52,10 @@ public struct ResetPasswordView<Header: View,
             headerContent
             
             createUsernameInput(for: authenticatorState.configuration.usernameAttribute)
-                .textInputAutocapitalization(.never)
                 .textContentType(.username)
+            #if os(iOS)
+                .textInputAutocapitalization(.never)
+            #endif
                       
             Button("authenticator.resetPassword.button.sendCode".localized()) {
                 Task {
@@ -65,6 +67,11 @@ public struct ResetPasswordView<Header: View,
             footerContent
         }
         .messageBanner($state.message)
+        .onSubmit {
+            Task {
+                await resetPassword()
+            }
+        }
     }
 
     @ViewBuilder private func createUsernameInput(
@@ -78,7 +85,9 @@ public struct ResetPasswordView<Header: View,
                 placeholder: "authenticator.field.username.placeholder".localized(),
                 validator: usernameValidator
             )
+        #if os(iOS)
             .keyboardType(.default)
+        #endif
         case .email:
             TextField(
                 "authenticator.field.email.label".localized(),
@@ -86,7 +95,9 @@ public struct ResetPasswordView<Header: View,
                 placeholder: "authenticator.field.email.placeholder".localized(),
                 validator: usernameValidator
             )
+        #if os(iOS)
             .keyboardType(.emailAddress)
+        #endif
         case .phoneNumber:
             TextField(
                 "authenticator.field.phoneNumber.label".localized(),
@@ -94,7 +105,9 @@ public struct ResetPasswordView<Header: View,
                 placeholder: "authenticator.field.phoneNumber.placeholder".localized(),
                 validator: usernameValidator
             )
+        #if os(iOS)
             .keyboardType(.phonePad)
+        #endif
         }
     }
 

--- a/Sources/Authenticator/Views/SignInView.swift
+++ b/Sources/Authenticator/Views/SignInView.swift
@@ -71,8 +71,10 @@ public struct SignInView<Header: View,
 
             createUsernameInput(for: authenticatorState.configuration.usernameAttribute)
                 .focused(focusedField.projectedValue, equals: .username)
-                .textInputAutocapitalization(.never)
                 .textContentType(.username)
+            #if os(iOS)
+                .textInputAutocapitalization(.never)
+            #endif
 
             PasswordField(
                 "authenticator.field.password.label".localized(),
@@ -82,7 +84,9 @@ public struct SignInView<Header: View,
             )
             .focused(focusedField.projectedValue, equals: .password)
             .textContentType(.password)
+        #if os(iOS)
             .textInputAutocapitalization(.never)
+        #endif
 
             Button("authenticator.signIn.button.signIn".localized()) {
                 Task {
@@ -97,7 +101,13 @@ public struct SignInView<Header: View,
         .messageBanner($state.message)
         .keyboardIterableToolbar(fields: self)
         .onSubmit {
-            focusNextField()
+            if hasNextField {
+                focusNextField()
+            } else {
+                Task {
+                    await signIn()
+                }
+            }
         }
         .onAppear {
             state.password = ""
@@ -153,7 +163,10 @@ public struct SignInView<Header: View,
                 placeholder: "authenticator.field.username.placeholder".localized(),
                 validator: usernameValidator
             )
+        #if os(iOS)
             .keyboardType(.default)
+        #endif
+
         case .email:
             TextField(
                 "authenticator.field.email.label".localized(),
@@ -161,7 +174,10 @@ public struct SignInView<Header: View,
                 placeholder: "authenticator.field.email.placeholder".localized(),
                 validator: usernameValidator
             )
+        #if os(iOS)
             .keyboardType(.emailAddress)
+        #endif
+
         case .phoneNumber:
             PhoneNumberField(
                 "authenticator.field.phoneNumber.label".localized(),
@@ -169,7 +185,9 @@ public struct SignInView<Header: View,
                 placeholder: "authenticator.field.phoneNumber.placeholder".localized(),
                 validator: usernameValidator
             )
+        #if os(iOS)
             .keyboardType(.numberPad)
+        #endif
         }
     }
 }

--- a/Sources/Authenticator/Views/SignUpView.swift
+++ b/Sources/Authenticator/Views/SignUpView.swift
@@ -54,8 +54,10 @@ public struct SignUpView<Header: View,
                     field: field,
                     validator: validators.validator(for: field.field)
                 )
-                .textInputAutocapitalization(.never)
                 .focused(focusedField.projectedValue, equals: field.field.attributeType)
+            #if os(iOS)
+                .textInputAutocapitalization(.never)
+            #endif
             }
                        
             Button("authenticator.signUp.button.createAccount".localized()) {
@@ -68,7 +70,13 @@ public struct SignUpView<Header: View,
             footerContent
         }
         .onSubmit {
-            focusNextField()
+            if hasNextField {
+                focusNextField()
+            } else {
+                Task {
+                    await signUp()
+                }
+            }
         }
         .animation(options.contentAnimation, value: state.fields)
         .messageBanner($state.message)


### PR DESCRIPTION
**Description of changes:**

Adding support for macOS 💻 

Main changes:
- Wrapping OS-specific code in the corresponding`#if os` annotations
- Creating a `Platform` enum for easy runtime check of the platform
- Dropping the manual styling for `Button`s in favour of a `ButtonStyle`, which works on macOS as well (the old approach didn't)
- Tweaking some UX to match what is expected in a desktop OS. For example, always showing the "clear" buttons in TextFields

Finally, for both platforms: I've made a change so that if the "enter" key is pressed on the last input field in a view, the Authenticator should attempt to submit the operation without the user having to tap/click on the button.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
