### PR TITLE
fix: Fixing password validations not working in the Sign Up view

### DIFF
--- a/Sources/Authenticator/Utilities/KeyboardIterableFields.swift
+++ b/Sources/Authenticator/Utilities/KeyboardIterableFields.swift
@@ -58,22 +58,19 @@ private struct KeyboardIterableToolbar<V>: ViewModifier where V: KeyboardIterabl
     func body(content: Content) -> some View {
         content
             .toolbar {
-                SwiftUI.ToolbarItem(placement: .keyboard) {
+                SwiftUI.ToolbarItemGroup(placement: .keyboard) {
                     SwiftUI.Button(action: fields.focusPreviousField) {
                         Image(systemName: "chevron.up")
                     }
                     .disabled(!fields.hasPreviousField)
-                }
-                SwiftUI.ToolbarItem(placement: .keyboard) {
+
                     SwiftUI.Button(action: fields.focusNextField) {
                         Image(systemName: "chevron.down")
                     }
                     .disabled(!fields.hasNextField)
-                }
-                SwiftUI.ToolbarItem(placement: .keyboard) {
+
                     Spacer()
-                }
-                SwiftUI.ToolbarItem(placement: .keyboard) {
+
                     SwiftUI.Button("authenticator.keyboardToolbar.Done".localized()) {
                         fields.focusedField.wrappedValue = nil
                     }

--- a/Sources/Authenticator/Views/SignUpView.swift
+++ b/Sources/Authenticator/Views/SignUpView.swift
@@ -192,12 +192,8 @@ extension SignUpView {
                         return field.isRequired ? FieldValidators.required(value) : nil
                     }
 
-                    if let validator = field.validator {
-                        return validator(value)
-                    }
-
                     guard let self = self else {
-                        return nil
+                        return field.validator?(value)
                     }
 
                     if case .password = field.attributeType {
@@ -210,7 +206,7 @@ extension SignUpView {
                         return "authenticator.validator.field.newPassword.doesNotMatch".localized()
                     }
 
-                    return nil
+                    return field.validator?(value)
                 }
             )
             validators[field.attributeType] = validator


### PR DESCRIPTION
**Description of changes:**

- Because all the "known" Sign Up fields have a default validator (that currently validates its value's max length), the custom password validators defined for the password and confirm password fields were never reached, resulting in them not being checked.

- As an additional improvement, I'm adding a single `ToolbarItemGroup` to the `KeyboardIterableFields` utility to replace having to create many `ToolbarItem`s .

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
