### PR TITLE
feat: Adding customization for Loading step and Busy states

### DIFF
--- a/Sources/Authenticator/Configuration/AuthenticatorOptions.swift
+++ b/Sources/Authenticator/Configuration/AuthenticatorOptions.swift
@@ -12,4 +12,10 @@ class AuthenticatorOptions: ObservableObject {
     @Published var contentAnimation: Animation = .easeInOut(duration: 0.25)
     @Published var contentTransition: AnyTransition = .opacity
     @Published var signUpFields: [SignUpField] = []
+    @Published var busyStyle = BusyStyle(content: ProgressView())
+
+    struct BusyStyle {
+        var blurRadius: CGFloat = 2
+        var content: any View
+    }
 }

--- a/Sources/Authenticator/Theming/AuthenticatorTheme.swift
+++ b/Sources/Authenticator/Theming/AuthenticatorTheme.swift
@@ -47,7 +47,6 @@ public class AuthenticatorTheme: ObservableObject {
             borderWidth: 1,
             backgroundColor: .clear
         )
-        public var loadingBlur: CGFloat = 2
     }
 
     public struct Button {

--- a/Sources/Authenticator/Views/Internal/AuthenticatorView.swift
+++ b/Sources/Authenticator/Views/Internal/AuthenticatorView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct AuthenticatorView<Content: View>: View {
     @Environment(\.authenticatorTheme) private var theme
+    @Environment(\.authenticatorOptions) private var options
     private var isBusy: Bool
     private let content: Content
 
@@ -28,11 +29,11 @@ struct AuthenticatorView<Content: View>: View {
                 .cornerRadius(theme.Authenticator.style.cornerRadius)
                 .padding(theme.Authenticator.style.padding/2)
             }
-            .blur(radius: isBusy ? theme.Authenticator.loadingBlur : 0)
+            .blur(radius: isBusy ? options.busyStyle.blurRadius : 0)
             .disabled(isBusy)
 
             if isBusy {
-                ProgressView()
+                AnyView(options.busyStyle.content)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/Authenticator/Views/ResetPasswordView.swift
+++ b/Sources/Authenticator/Views/ResetPasswordView.swift
@@ -99,7 +99,7 @@ public struct ResetPasswordView<Header: View,
             .keyboardType(.emailAddress)
         #endif
         case .phoneNumber:
-            TextField(
+            PhoneNumberField(
                 "authenticator.field.phoneNumber.label".localized(),
                 text: $state.username,
                 placeholder: "authenticator.field.phoneNumber.placeholder".localized(),


### PR DESCRIPTION
**Description of changes:**

This PR adds the ability to customize:
 - The content associated with the `.loading` step, i.e. when the user session is being fetch at the beginning
 - The blur intensity and content that is used by all the default views while an operation is in progress.
   -  To support this I've removed the `loadingBlur` property from the `AuthenticatorTheme`, which is not really part of a theme if you think about it.

Misc changes:
 - Removing leftover unnecessary `@escaping` annotations from the Authenticator's init
 - Using the right `PhoneNumberField` view in the `ResetPasswordView`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
