### PR TITLE
fix: Adding missing calling codes

### DIFF
--- a/Sources/Authenticator/Resources/en.lproj/Localizable.strings
+++ b/Sources/Authenticator/Resources/en.lproj/Localizable.strings
@@ -7,7 +7,7 @@
 
 /* Authenticator Fields */
 "authenticator.field.label.optional" = "%@ (Optional)"; // Argument is the field's name. E.g. "Username"
-"authenticator.countryCodes.search" = "Search country";
+"authenticator.countryCodes.search" = "Search region";
 
 "authenticator.field.date.label" = "Select a date";
 "authenticator.imageButton.close" = "Close";

--- a/Sources/Authenticator/Utilities/RegionUtils.swift
+++ b/Sources/Authenticator/Utilities/RegionUtils.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Country: Equatable, Hashable {
+struct Region: Equatable, Hashable {
     let name: String
     let code: String
     let callingCode: String
@@ -26,7 +26,7 @@ struct Country: Equatable, Hashable {
 }
 
 extension Locale {
-    var countryCode: String {
+    var isoRegionCode: String {
         if #available(iOS 16, macOS 13, *) {
             return region?.identifier ?? ""
         } else {
@@ -34,7 +34,7 @@ extension Locale {
         }
     }
 
-    func countryName(forCode code: String) -> String? {
+    func displayName(forCode code: String) -> String? {
         return (self as NSLocale).displayName(
             forKey: .countryCode,
             value: code
@@ -42,19 +42,19 @@ extension Locale {
     }
 }
 
-class CountryUtils {
-    static let shared: CountryUtils = .init()
+class RegionUtils {
+    static let shared: RegionUtils = .init()
     private var locale: Locale {
         Locale.current
     }
 
     private init() {}
 
-    lazy var allCountries: [Country] = {
-        var countries: [Country] = []
+    lazy var allRegions: [Region] = {
+        var regions: [Region] = []
         for code in allCallingCodes {
-            if let name = locale.countryName(forCode: code.key) {
-                countries.append(.init(
+            if let name = locale.displayName(forCode: code.key) {
+                regions.append(.init(
                     name: name,
                     code: code.key,
                     callingCode: code.value)
@@ -62,11 +62,11 @@ class CountryUtils {
             }
         }
 
-        return countries.sorted(by: { $0.name < $1.name })
+        return regions.sorted(by: { $0.name < $1.name })
     }()
 
     var currentCallingCode: String {
-        return allCallingCodes[locale.countryCode] ?? ""
+        return allCallingCodes[locale.isoRegionCode] ?? ""
     }
 
     private let allCallingCodes = [
@@ -77,13 +77,14 @@ class CountryUtils {
         "AI": "+1",
         "AL": "+355",
         "AM": "+374",
-        "AN": "+599",
         "AO": "+244",
+        "AQ": "+672",
         "AR": "+54",
         "AS": "+1",
         "AT": "+43",
         "AU": "+61",
         "AW": "+297",
+        "AX": "+358",
         "AZ": "+994",
         "BA": "+387",
         "BB": "+1",
@@ -98,9 +99,11 @@ class CountryUtils {
         "BM": "+1",
         "BN": "+673",
         "BO": "+591",
+        "BQ": "+599",
         "BR": "+55",
         "BS": "+1",
         "BT": "+975",
+        "BV": "+47",
         "BW": "+267",
         "BY": "+375",
         "BZ": "+501",
@@ -119,6 +122,7 @@ class CountryUtils {
         "CR": "+506",
         "CU": "+53",
         "CV": "+238",
+        "CW": "+599",
         "CX": "+61",
         "CY": "+537",
         "CZ": "+420",
@@ -131,6 +135,7 @@ class CountryUtils {
         "EC": "+593",
         "EE": "+372",
         "EG": "+20",
+        "EH": "+212",
         "ER": "+291",
         "ES": "+34",
         "ET": "+251",
@@ -160,6 +165,7 @@ class CountryUtils {
         "GW": "+245",
         "GY": "+595",
         "HK": "+852",
+        "HM": "+672",
         "HN": "+504",
         "HR": "+385",
         "HT": "+509",
@@ -271,12 +277,15 @@ class CountryUtils {
         "SN": "+221",
         "SO": "+252",
         "SR": "+597",
+        "SS": "+211",
         "ST": "+239",
         "SV": "+503",
+        "SX": "+599",
         "SY": "+963",
         "SZ": "+268",
         "TC": "+1",
         "TD": "+235",
+        "TF": "+262",
         "TG": "+228",
         "TH": "+66",
         "TJ": "+992",

--- a/Sources/Authenticator/Views/Primitives/PhoneNumberField.swift
+++ b/Sources/Authenticator/Views/Primitives/PhoneNumberField.swift
@@ -17,7 +17,7 @@ struct PhoneNumberField: View {
     @Binding private var text: String
     @FocusState private var isFocused: Bool
     @FocusState private var focusedField: FieldType?
-    @State private var callingCode: String = CountryUtils.shared.currentCallingCode
+    @State private var callingCode: String = RegionUtils.shared.currentCallingCode
     @State private var phoneNumber: String = ""
 
     private let label: String?
@@ -56,7 +56,7 @@ struct PhoneNumberField: View {
             isFocused: focusedField != nil
         ) {
             HStack(spacing: 0) {
-                CountryCodeList(callingCode: $callingCode)
+                CallingCodeField(callingCode: $callingCode)
                     .foregroundColor(foregroundColor)
                     .focused($focusedField, equals: .callingCode)
                     .onChange(of: callingCode) { text in
@@ -149,13 +149,13 @@ struct PhoneNumberField: View {
 
 /// This allows the user to select a dialing code from a list of all available ones,
 /// showing a localized name of the region associated with each code and its flag
-struct CountryCodeList: View {
+struct CallingCodeField: View {
     @Environment(\.authenticatorTheme) var theme
-    @State private var searchCountry: String = ""
+    @State private var searchRegion: String = ""
     @State private var isShowingList = false
     @FocusState private var isFocused: Bool
     @Binding var callingCode: String
-    private let defaultCallingCode = CountryUtils.shared.currentCallingCode
+    private let defaultCallingCode = RegionUtils.shared.currentCallingCode
     private let maxCallingCodeLength = 4
 
     var body: some View {
@@ -205,70 +205,70 @@ struct CountryCodeList: View {
         .buttonStyle(.borderless)
         .sheet(isPresented: $isShowingList) {
             if #available(iOS 16.0, macOS 13.0, *) {
-                allCountriesContent
+                allRegionsContent
                     .presentationDetents([.medium, .large])
             } else {
-                allCountriesContent
+                allRegionsContent
             }
         }
     }
 
-    private var allCountriesContent: some View {
+    private var allRegionsContent: some View {
     #if os(iOS)
         NavigationView {
-            countryList
+            regionList
         }
         .searchable(
-            text: $searchCountry,
+            text: $searchRegion,
             placement: .navigationBarDrawer(displayMode: .always),
             prompt: "authenticator.countryCodes.search".localized()
         )
         .keyboardType(.default)
     #elseif os(macOS)
         VStack {
-            SwiftUI.TextField("authenticator.countryCodes.search".localized(), text: $searchCountry)
+            SwiftUI.TextField("authenticator.countryCodes.search".localized(), text: $searchRegion)
                 .padding([.leading, .top, .trailing])
                 .textFieldStyle(.plain)
             Divider()
-            countryList
+            regionList
         }
         .frame(width: 400, height: 300)
     #endif
     }
 
-    private var countryList: some View {
+    private var regionList: some View {
         List {
-            ForEach(countries, id: \.self) { country in
+            ForEach(regions, id: \.self) { region in
                 SwiftUI.Button(
                     action: {
-                        callingCode = country.callingCode
+                        callingCode = region.callingCode
                         isShowingList = false
                     },
                     label: {
                         HStack {
-                            Text("\(country.flag) \(country.name)")
+                            Text("\(region.flag) \(region.name)")
                             Spacer()
-                            Text("\(country.callingCode)")
+                            Text("\(region.callingCode)")
                         }
                     }
                 )
                 .buttonStyle(.borderless)
-                .accessibilityLabel(Text(country.name))
+                .accessibilityLabel(Text(region.name))
             }
         }
         .foregroundColor(theme.Colors.Foreground.primary)
         .listStyle(.plain)
     }
 
-    private var countries: [Country] {
-        let allCountries = CountryUtils.shared.allCountries
-        guard !searchCountry.isEmpty else {
-            return allCountries
+    private var regions: [Region] {
+        let allRegions = RegionUtils.shared.allRegions
+        guard !searchRegion.isEmpty else {
+            return allRegions
         }
 
-        return allCountries.filter {
-            $0.name.lowercased().contains(searchCountry.lowercased())
-            || $0.callingCode.lowercased().contains(searchCountry.lowercased())
+        return allRegions.filter {
+            $0.name.lowercased().contains(searchRegion.lowercased())
+            || $0.callingCode.lowercased().contains(searchRegion.lowercased())
         }
     }
 }


### PR DESCRIPTION
**Description of changes:**

- Adding the following missing region codes and their calling codes: `AQ`, `AX`, `BV`, `EH`, `HM`, `SS`, `TF`.
- Splitting `AN` into `BQ`, `CW` and `SX`, to match the current ISO 3166 definition.
- Using the term "Region" instead across the code, to be more accurate to what they represent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
