### PR TITLE
feat: Finalizing Theming capabilities.

### DIFF
--- a/Sources/Authenticator/Theming/AuthenticatorTheme.swift
+++ b/Sources/Authenticator/Theming/AuthenticatorTheme.swift
@@ -7,21 +7,34 @@
 
 import SwiftUI
 
+/// Represents a theme that is used to style the ``Authenticator``
 public class AuthenticatorTheme: ObservableObject {
-    public struct Spacing {
-        public var horizontal: CGFloat
-        public var vertical: CGFloat
-    }
+    /// Theming options for specific components
+    public var components = Components()
+    
+    /// Defines the default fonts used by all components
+    public var fonts = Fonts()
+    
+    /// Defines the default colors used by all components
+    public var colors = Colors()
+}
 
-    public struct Style {
-        public var cornerRadius: CGFloat
-        public var padding: CGFloat
-        public var borderWidth: CGFloat
-        public var backgroundColor: Color
+extension AuthenticatorTheme {
+    public struct Components {
+        /// Theming options for the ``Authenticator`` component
+        public var authenticator = Authenticator()
+        
+        /// Theming options for buttons
+        public var button = Button()
+        
+        /// Theming options for input fields
+        public var field = Field()
+        
+        /// Theming options for alerts
+        public var alert = Alert()
     }
-
-    public struct Font {
-        init() {}
+    
+    public struct Fonts {
         public var largeTitle: SwiftUI.Font = .largeTitle
         public var title: SwiftUI.Font = .title
         public var title2: SwiftUI.Font = .title2
@@ -35,44 +48,131 @@ public class AuthenticatorTheme: ObservableObject {
         public var footnote: SwiftUI.Font = .footnote
     }
 
+    public struct Colors {
+        /// The colors used for foreground elements
+        public var foreground: Color = SwiftUI.Color.AmplifyUI.Font
+        
+        /// The colors used for backgrounds elements
+        public var background: Color = SwiftUI.Color.AmplifyUI.Background
+        
+        /// The colors used for borders
+        public var border: Color = SwiftUI.Color.AmplifyUI.Border
+    }
+    
+    public struct Spacing {
+        public var horizontal: CGFloat
+        public var vertical: CGFloat
+    }
+    
+    /// Represents the padding that a component applies
+    public struct Padding: ExpressibleByFloatLiteral, ExpressibleByIntegerLiteral {
+        public var top: CGFloat
+        public var bottom: CGFloat
+        public var trailing: CGFloat
+        public var leading: CGFloat
+        
+        /// Creates a Padding with specific values for each of the given edges
+        public init(
+            top: CGFloat,
+            bottom: CGFloat,
+            trailing: CGFloat,
+            leading: CGFloat
+        ) {
+            self.top = top
+            self.bottom = bottom
+            self.trailing = trailing
+            self.leading = leading
+        }
+        
+        /// Creates a Padding that has the same given value for all edges
+        public init(floatLiteral value: Double) {
+            self.top = value
+            self.bottom = value
+            self.trailing = value
+            self.leading = value
+        }
+        
+        /// Creates a Padding that has the same given value for all edges
+        public init(integerLiteral value: Int) {
+            let all = CGFloat(integerLiteral: value)
+            self.top = all
+            self.bottom = all
+            self.trailing = all
+            self.leading = all
+        }
+
+        public static func /(lhs: Padding, rhs: Int) -> Padding {
+            let divider = CGFloat(rhs)
+            return Padding(
+                top: lhs.top/divider,
+                bottom: lhs.bottom/divider,
+                trailing: lhs.trailing/divider,
+                leading: lhs.leading/divider
+            )
+        }
+    }
+}
+
+extension AuthenticatorTheme.Colors {
+    /// Represents a group of colors
+    public struct Color {
+        public var primary: SwiftUI.Color
+        public var secondary: SwiftUI.Color
+        public var tertiary: SwiftUI.Color
+        public var disabled: SwiftUI.Color
+        public var inverse: SwiftUI.Color
+        public var interactive: SwiftUI.Color
+        public var info: SwiftUI.Color
+        public var warning: SwiftUI.Color
+        public var error: SwiftUI.Color
+        public var success: SwiftUI.Color
+
+        public init(
+            primary: SwiftUI.Color,
+            secondary: SwiftUI.Color,
+            tertiary: SwiftUI.Color,
+            disabled: SwiftUI.Color,
+            inverse: SwiftUI.Color,
+            interactive: SwiftUI.Color,
+            info: SwiftUI.Color,
+            warning: SwiftUI.Color,
+            error: SwiftUI.Color,
+            success: SwiftUI.Color
+        ) {
+            self.primary = primary
+            self.secondary = secondary
+            self.tertiary = tertiary
+            self.disabled = disabled
+            self.inverse = inverse
+            self.interactive = interactive
+            self.info = info
+            self.warning = warning
+            self.error = error
+            self.success = success
+        }
+    }
+}
+
+extension AuthenticatorTheme.Components {
     public struct Authenticator {
         init() {}
-        public var spacing = Spacing (
-            horizontal: 5,
+        public var spacing: AuthenticatorTheme.Spacing = .init(
+            horizontal: 0,
             vertical: Platform.isMacOS ? 15 : 20
         )
-        public var style = Style(
-            cornerRadius: 0,
-            padding: 20,
-            borderWidth: 1,
-            backgroundColor: .clear
-        )
+        public var padding: AuthenticatorTheme.Padding = 20
+        public var cornerRadius: CGFloat = 0
+        public var borderWidth: CGFloat = 1
+        public var backgroundColor: SwiftUI.Color = .clear
     }
 
     public struct Button {
-        init() {}
-        public struct Size {
-            public var font: SwiftUI.Font
-            public var cornerRadius: CGFloat
-            public var padding: CGFloat?
-
-            public init(
-                font: SwiftUI.Font,
-                cornerRadius: CGFloat,
-                padding: CGFloat? = nil
-            ) {
-                self.font = font
-                self.cornerRadius = cornerRadius
-                self.padding = padding
-            }
-        }
-
-        public var primary = Size(
+        public var primary = Variation(
             font: Platform.isMacOS ? .title3.bold() : .body.bold(),
             cornerRadius: 5,
             padding: 13
         )
-        public var link = Size(
+        public var link = Variation(
             font: Platform.isMacOS ? .body.weight(.semibold) : .subheadline.weight(.semibold),
             cornerRadius: 0,
             padding: 10
@@ -81,75 +181,36 @@ public class AuthenticatorTheme: ObservableObject {
 
     public struct Field {
         init() {}
-        public var spacing = Spacing(
+        public var spacing: AuthenticatorTheme.Spacing = .init(
             horizontal: Platform.isMacOS ? 5 : 0,
             vertical: 5
         )
-        public var style = Style(
-            cornerRadius: 5,
-            padding: 10,
-            borderWidth: 1,
-            backgroundColor: Platform.isMacOS ? .AmplifyUI.Background.primary : .clear
-        )
+        public var padding: AuthenticatorTheme.Padding = 10
+        public var cornerRadius: CGFloat = 5
+        public var borderWidth: CGFloat = 1
+        public var backgroundColor: SwiftUI.Color = Platform.isMacOS ? .AmplifyUI.Background.primary : .clear
     }
-
-    public struct Banner {
-        init() {}
+    
+    public struct Alert {
         public var cornerRadius: CGFloat = 10
-        public var padding: CGFloat = 30
+        public var padding: AuthenticatorTheme.Padding = 30
     }
+}
 
-    public struct Colors {
-        init() {}
-        public struct Color {
+extension AuthenticatorTheme.Components.Button {
+    public struct Variation {
+        public var font: SwiftUI.Font
+        public var cornerRadius: CGFloat
+        public var padding: AuthenticatorTheme.Padding?
 
-            public var primary: SwiftUI.Color
-            public var secondary: SwiftUI.Color
-            public var tertiary: SwiftUI.Color
-            public var disabled: SwiftUI.Color
-            public var inverse: SwiftUI.Color
-            public var interactive: SwiftUI.Color
-            public var info: SwiftUI.Color
-            public var warning: SwiftUI.Color
-            public var error: SwiftUI.Color
-            public var success: SwiftUI.Color
-
-            public init(
-                primary: SwiftUI.Color,
-                secondary: SwiftUI.Color,
-                tertiary: SwiftUI.Color,
-                disabled: SwiftUI.Color,
-                inverse: SwiftUI.Color,
-                interactive: SwiftUI.Color,
-                info: SwiftUI.Color,
-                warning: SwiftUI.Color,
-                error: SwiftUI.Color,
-                success: SwiftUI.Color
-            ) {
-                self.primary = primary
-                self.secondary = secondary
-                self.tertiary = tertiary
-                self.disabled = disabled
-                self.inverse = inverse
-                self.interactive = interactive
-                self.info = info
-                self.warning = warning
-                self.error = error
-                self.success = success
-            }
+        public init(
+            font: SwiftUI.Font,
+            cornerRadius: CGFloat,
+            padding: AuthenticatorTheme.Padding? = nil
+        ) {
+            self.font = font
+            self.cornerRadius = cornerRadius
+            self.padding = padding
         }
-
-        public var Foreground = SwiftUI.Color.AmplifyUI.Font
-        public var Background = SwiftUI.Color.AmplifyUI.Background
-        public var Border = SwiftUI.Color.AmplifyUI.Border
     }
-
-    public var Authenticator = Authenticator()
-    public var Buttons = Button()
-    public var Fonts = Font()
-    public var Colors = Colors()
-    public var Banners = Banner()
-    public var Fields = Field()
-
-    public init() {}
 }

--- a/Sources/Authenticator/Utilities/AuthenticatorField.swift
+++ b/Sources/Authenticator/Utilities/AuthenticatorField.swift
@@ -30,21 +30,21 @@ struct AuthenticatorField<Content: View>: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: theme.Fields.spacing.vertical) {
+        VStack(alignment: .leading, spacing: theme.components.field.spacing.vertical) {
             if let label = label {
                 SwiftUI.Text(label)
                     .foregroundColor(foregroundColor)
-                    .font(theme.Fonts.body)
+                    .font(theme.fonts.body)
                     .accessibilityHidden(true)
             }
 
             content
             .background(
-                RoundedRectangle(cornerRadius: theme.Fields.style.cornerRadius, style: .continuous)
+                RoundedRectangle(cornerRadius: theme.components.field.cornerRadius, style: .continuous)
                     .fill(backgroundColor)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: theme.Fields.style.cornerRadius)
+                RoundedRectangle(cornerRadius: theme.components.field.cornerRadius)
                     .stroke(borderColor,
                             lineWidth: borderWidth)
 
@@ -52,7 +52,7 @@ struct AuthenticatorField<Content: View>: View {
 
             if let errorMessage = errorMessage {
                 SwiftUI.Text(errorMessage)
-                    .font(theme.Fonts.subheadline)
+                    .font(theme.fonts.subheadline)
                     .foregroundColor(foregroundColor)
                     .transition(options.contentTransition)
                     .accessibilityHidden(true)
@@ -65,8 +65,8 @@ struct AuthenticatorField<Content: View>: View {
     }
 
     private var backgroundColor: Color {
-        isEnabled ? theme.Fields.style.backgroundColor : Color(
-            light: theme.Colors.Background.disabled,
+        isEnabled ? theme.components.field.backgroundColor : Color(
+            light: theme.colors.background.disabled,
             dark: .clear
         )
     }
@@ -74,9 +74,9 @@ struct AuthenticatorField<Content: View>: View {
     private var foregroundColor: Color {
         switch validator.state {
         case .normal:
-            return theme.Colors.Foreground.secondary
+            return theme.colors.foreground.secondary
         case .error:
-            return theme.Colors.Foreground.error
+            return theme.colors.foreground.error
         }
     }
 
@@ -84,15 +84,15 @@ struct AuthenticatorField<Content: View>: View {
         switch validator.state {
         case .normal:
             return isFocused ?
-                theme.Colors.Border.interactive : theme.Colors.Border.primary
+                theme.colors.border.interactive : theme.colors.border.primary
 
         case .error:
-            return theme.Colors.Border.error
+            return theme.colors.border.error
         }
     }
 
     private var borderWidth: CGFloat {
-        let width = theme.Fields.style.borderWidth
+        let width = theme.components.field.borderWidth
         return isFocused ? width + 1 : width
     }
 

--- a/Sources/Authenticator/Utilities/Padding.swift
+++ b/Sources/Authenticator/Utilities/Padding.swift
@@ -1,0 +1,51 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import SwiftUI
+
+extension View {
+    func padding(_ padding: AuthenticatorTheme.Padding?) -> some View {
+        modifier(PaddingModifier(padding: padding))
+    }
+    
+    func padding(_ edges: [Edge], _ padding: AuthenticatorTheme.Padding?) -> some View {
+        modifier(PaddingWithEdgesModifier(edges: edges, padding: padding))
+    }
+    
+    @ViewBuilder fileprivate func padding(_ edges: Edge.Set, _ padding: CGFloat?, if condition: Bool) -> some View {
+        if condition {
+            self.padding(edges, padding)
+        } else {
+            self
+        }
+    }
+}
+
+private struct PaddingModifier: ViewModifier {
+    var padding: AuthenticatorTheme.Padding?
+
+    func body(content: Content) -> some View {
+        content
+            .padding([.top], padding?.top)
+            .padding([.bottom], padding?.bottom)
+            .padding([.leading], padding?.leading)
+            .padding([.trailing], padding?.trailing)
+    }
+}
+
+private struct PaddingWithEdgesModifier: ViewModifier {
+    var edges: [Edge]
+    var padding: AuthenticatorTheme.Padding?
+
+    func body(content: Content) -> some View {
+        content
+            .padding([.top], padding?.top, if: edges.contains(.top))
+            .padding([.bottom], padding?.bottom, if: edges.contains(.bottom))
+            .padding([.leading], padding?.leading, if: edges.contains(.leading))
+            .padding([.trailing], padding?.trailing, if: edges.contains(.trailing))
+    }
+}

--- a/Sources/Authenticator/Views/ConfirmSignUpView.swift
+++ b/Sources/Authenticator/Views/ConfirmSignUpView.swift
@@ -63,7 +63,7 @@ public struct ConfirmSignUpView<Header: View,
 
             HStack(alignment: .center) {
                 Text("authenticator.confirmSignUp.lostCode".localized())
-                    .font(theme.Fonts.body)
+                    .font(theme.fonts.body)
                 Spacer()
                 Button("authenticator.confirmSignUp.button.sendCode".localized()) {
                     Task {

--- a/Sources/Authenticator/Views/ErrorView.swift
+++ b/Sources/Authenticator/Views/ErrorView.swift
@@ -18,10 +18,10 @@ public struct ErrorView: View {
             DefaultHeader(
                 title: "authenticator.authenticatorError.title".localized()
             )
-            .foregroundColor(theme.Colors.Border.error)
+            .foregroundColor(theme.colors.border.error)
             
             SwiftUI.Text("authenticator.authenticatorError.message".localized())
-                .foregroundColor(theme.Colors.Foreground.error)
+                .foregroundColor(theme.colors.foreground.error)
             
             Spacer()
         }

--- a/Sources/Authenticator/Views/Internal/AuthenticatorMessageView.swift
+++ b/Sources/Authenticator/Views/Internal/AuthenticatorMessageView.swift
@@ -83,7 +83,7 @@ private struct AuthenticatorMessageView: View {
     var body: some View {
         HStack {
             Text(message.content)
-                .font(theme.Fonts.callout)
+                .font(theme.fonts.callout)
             Spacer()
             ImageButton(.close) {
                 action()
@@ -92,31 +92,31 @@ private struct AuthenticatorMessageView: View {
         }
         .frame(maxWidth: .infinity)
         .foregroundColor(foregroundColor)
-        .padding(theme.Banners.padding/2)
+        .padding(theme.components.alert.padding/2)
         .background(backgroundColor)
-        .cornerRadius(theme.Banners.cornerRadius)
-        .padding(theme.Banners.padding/2)
+        .cornerRadius(theme.components.alert.cornerRadius)
+        .padding(theme.components.alert.padding/2)
     }
 
     private var foregroundColor: Color {
         switch message.style {
         case .error:
-            return theme.Colors.Foreground.error
+            return theme.colors.foreground.error
         case .info:
-            return theme.Colors.Foreground.info
+            return theme.colors.foreground.info
         default:
-            return theme.Colors.Foreground.primary
+            return theme.colors.foreground.primary
         }
     }
 
     private var backgroundColor: Color {
         switch message.style {
         case .error:
-            return theme.Colors.Background.error
+            return theme.colors.background.error
         case .info:
-            return theme.Colors.Background.info
+            return theme.colors.background.info
         default:
-            return theme.Colors.Background.primary
+            return theme.colors.background.primary
         }
     }
 }

--- a/Sources/Authenticator/Views/Internal/AuthenticatorView.swift
+++ b/Sources/Authenticator/Views/Internal/AuthenticatorView.swift
@@ -21,13 +21,13 @@ struct AuthenticatorView<Content: View>: View {
     var body: some View {
         ZStack {
             ScrollView {
-                VStack(spacing: theme.Authenticator.spacing.vertical) {
+                VStack(spacing: theme.components.authenticator.spacing.vertical) {
                     content
                 }
-                .padding(theme.Authenticator.style.padding/2)
-                .background(theme.Authenticator.style.backgroundColor)
-                .cornerRadius(theme.Authenticator.style.cornerRadius)
-                .padding(theme.Authenticator.style.padding/2)
+                .padding(theme.components.authenticator.padding/2)
+                .background(theme.components.authenticator.backgroundColor)
+                .cornerRadius(theme.components.authenticator.cornerRadius)
+                .padding(theme.components.authenticator.padding/2)
             }
             .blur(radius: isBusy ? options.busyStyle.blurRadius : 0)
             .disabled(isBusy)

--- a/Sources/Authenticator/Views/Internal/DefaultHeader.swift
+++ b/Sources/Authenticator/Views/Internal/DefaultHeader.swift
@@ -20,8 +20,8 @@ struct DefaultHeader: View {
     var body: some View {
         HStack {
             SwiftUI.Text(title)
-                .font(font ?? theme.Fonts.title)
-                .foregroundColor(foregroundColor ?? theme.Colors.Foreground.primary)
+                .font(font ?? theme.fonts.title)
+                .foregroundColor(foregroundColor ?? theme.colors.foreground.primary)
             .accessibilityAddTraits(.isHeader)
             Spacer()
         }

--- a/Sources/Authenticator/Views/Internal/SignUpInputField.swift
+++ b/Sources/Authenticator/Views/Internal/SignUpInputField.swift
@@ -83,7 +83,7 @@ struct SignUpInputField: View {
             if case .error(let message) = validator.state, let errorMessage = message {
                 AnyView(
                     field.errorContent(errorMessage)
-                        .font(theme.Fonts.subheadline)
+                        .font(theme.fonts.subheadline)
                 )
                     .foregroundColor(borderColor)
                     .transition(options.contentTransition)
@@ -94,9 +94,9 @@ struct SignUpInputField: View {
     private var borderColor: Color {
         switch validator.state {
         case .normal:
-            return theme.Colors.Border.primary
+            return theme.colors.border.primary
         case .error:
-            return theme.Colors.Border.error
+            return theme.colors.border.error
         }
     }
 }

--- a/Sources/Authenticator/Views/Primitives/Button.swift
+++ b/Sources/Authenticator/Views/Primitives/Button.swift
@@ -30,40 +30,40 @@ struct Button: View {
     private var backgroundColor: Color {
         switch viewModifiers.style {
         case .primary:
-            return theme.Colors.Background.interactive
+            return theme.colors.background.interactive
         case .link:
             return .clear
         default:
-            return theme.Colors.Background.error
+            return theme.colors.background.error
         }
     }
 
     private var foregroundColor: Color {
         switch viewModifiers.style {
         case .primary:
-            return theme.Colors.Foreground.inverse
+            return theme.colors.foreground.inverse
         case .link:
-            return theme.Colors.Foreground.interactive
+            return theme.colors.foreground.interactive
         default:
-            return theme.Colors.Foreground.primary
+            return theme.colors.foreground.primary
         }
     }
 
     private var cornerRadius: CGFloat {
         switch viewModifiers.style {
         case .primary:
-            return theme.Buttons.primary.cornerRadius
+            return theme.components.button.primary.cornerRadius
         case .link:
-            return theme.Buttons.link.cornerRadius
+            return theme.components.button.link.cornerRadius
         default:
-            return theme.Authenticator.style.cornerRadius
+            return theme.components.authenticator.cornerRadius
         }
     }
 
     private var borderColor: Color {
         switch viewModifiers.style {
         case .default:
-            return theme.Colors.Border.interactive
+            return theme.colors.border.interactive
         default:
             return .clear
         }
@@ -72,7 +72,7 @@ struct Button: View {
     private var borderWidth: CGFloat {
         switch viewModifiers.style {
         case .default:
-            return theme.Authenticator.style.borderWidth
+            return theme.components.authenticator.borderWidth
         default:
             return 0
         }
@@ -81,22 +81,22 @@ struct Button: View {
     private var font: Font {
         switch viewModifiers.style {
         case .primary:
-            return theme.Buttons.primary.font
+            return theme.components.button.primary.font
         case .link:
-            return theme.Buttons.link.font
+            return theme.components.button.link.font
         default:
-            return theme.Fonts.body
+            return theme.fonts.body
         }
     }
 
-    private var padding: CGFloat? {
+    private var padding: AuthenticatorTheme.Padding? {
         switch viewModifiers.style {
         case .primary:
-            return theme.Buttons.primary.padding
+            return theme.components.button.primary.padding
         case .link:
-            return theme.Buttons.link.padding
+            return theme.components.button.link.padding
         default:
-            return theme.Authenticator.style.padding
+            return theme.components.authenticator.padding
         }
     }
 
@@ -171,13 +171,13 @@ private struct AuthenticatorButtonStyle: ButtonStyle {
     let foregroundColor: Color
     let backgroundColor: Color
     let cornerRadius: CGFloat
-    let padding: CGFloat?
+    let padding: AuthenticatorTheme.Padding?
     let maxWidth: CGFloat?
 
     func makeBody(configuration: Self.Configuration) -> some View {
         configuration.label
             .font(font)
-            .padding(.all, padding)
+            .padding(padding)
             .multilineTextAlignment(.center)
             .frame(maxWidth: maxWidth)
             .foregroundColor(configuration.isPressed ? foregroundColor.opacity(0.5) : foregroundColor)

--- a/Sources/Authenticator/Views/Primitives/DatePicker.swift
+++ b/Sources/Authenticator/Views/Primitives/DatePicker.swift
@@ -35,11 +35,11 @@ struct DatePicker: View {
     }
 
     var body: some View {
-        VStack(alignment: .trailing, spacing: theme.Fields.spacing.vertical) {
-            HStack(alignment: .center, spacing: theme.Fields.spacing.horizontal) {
+        VStack(alignment: .trailing, spacing: theme.components.field.spacing.vertical) {
+            HStack(alignment: .center, spacing: theme.components.field.spacing.horizontal) {
                 SwiftUI.Text(label)
                     .foregroundColor(foregroundColor)
-                    .font(theme.Fonts.body)
+                    .font(theme.fonts.body)
                     .accessibilityHidden(true)
 
                 Spacer()
@@ -56,7 +56,7 @@ struct DatePicker: View {
                             updateDate(selectedDate)
                         }
                         .tintColor(tintColor)
-                        .padding([.top, .bottom], theme.Fields.style.padding)
+                        .padding([.top, .bottom], theme.components.field.padding)
                         .accessibilityHidden(true)
                     }
                     .accessibilityAddTraits(.isButton)
@@ -68,7 +68,7 @@ struct DatePicker: View {
                         displayedComponents: .date
                     )
                     .fixedSize()
-                    .tint(theme.Colors.Background.interactive)
+                    .tint(theme.colors.background.interactive)
                     .focused($isFocused)
                     .onChange(of: selectedDate) { date in
                         updateDate(date)
@@ -85,13 +85,13 @@ struct DatePicker: View {
                         validator.validate()
                     }
                     .tintColor(tintColor)
-                    .padding([.top, .bottom], theme.Fields.style.padding)
+                    .padding([.top, .bottom], theme.components.field.padding)
                 }
             }
 
             if let errorMessage = errorMessage {
                 SwiftUI.Text(errorMessage)
-                    .font(theme.Fonts.subheadline)
+                    .font(theme.fonts.subheadline)
                     .foregroundColor(borderColor)
                 .transition(options.contentTransition)
             }
@@ -105,7 +105,7 @@ struct DatePicker: View {
 
     private var tintColor: Color {
         if actualDate == nil {
-            return theme.Colors.Background.interactive
+            return theme.colors.background.interactive
         }
 
         return borderColor
@@ -113,7 +113,7 @@ struct DatePicker: View {
 
     private var backgroundColor: Color {
         isEnabled ? .clear : Color(
-            light: theme.Colors.Background.disabled,
+            light: theme.colors.background.disabled,
             dark: .clear
         )
     }
@@ -121,18 +121,18 @@ struct DatePicker: View {
     private var foregroundColor: Color {
         switch validator.state {
         case .normal:
-            return theme.Colors.Foreground.secondary
+            return theme.colors.foreground.secondary
         case .error:
-            return theme.Colors.Foreground.error
+            return theme.colors.foreground.error
         }
     }
 
     private var borderColor: Color {
         switch validator.state {
         case .normal:
-            return theme.Colors.Border.primary
+            return theme.colors.border.primary
         case .error:
-            return theme.Colors.Border.error
+            return theme.colors.border.error
         }
     }
 

--- a/Sources/Authenticator/Views/Primitives/PasswordField.swift
+++ b/Sources/Authenticator/Views/Primitives/PasswordField.swift
@@ -66,7 +66,7 @@ struct PasswordField: View {
                     }
                     .textFieldStyle(.plain)
                     .frame(height: Platform.isMacOS ? 20 : 25)
-                    .padding([.top, .bottom, .leading], theme.Fields.style.padding)
+                    .padding([.top, .bottom, .leading], theme.components.field.padding)
                 #if os(iOS)
                     .autocapitalization(.none)
                 #endif
@@ -77,7 +77,7 @@ struct PasswordField: View {
                         focusedField = isShowingPassword ? .plain : .secure
                     }
                     .tintColor(showPasswordButtonColor)
-                    .padding([.top, .bottom, .trailing], theme.Fields.style.padding)
+                    .padding([.top, .bottom, .trailing], theme.components.field.padding)
                 }
             }
             .animation(.linear(duration: 0.1), value: isShowingPassword)
@@ -102,9 +102,9 @@ struct PasswordField: View {
         switch validator.state {
         case .normal:
             return isFocused ?
-                theme.Colors.Border.interactive : theme.Colors.Border.primary
+                theme.colors.border.interactive : theme.colors.border.primary
         case .error:
-            return theme.Colors.Border.error
+            return theme.colors.border.error
         }
     }
 

--- a/Sources/Authenticator/Views/Primitives/PhoneNumberField.swift
+++ b/Sources/Authenticator/Views/Primitives/PhoneNumberField.swift
@@ -65,7 +65,7 @@ struct PhoneNumberField: View {
 
                 Divider()
                     .frame(width: 1)
-                    .overlay(theme.Colors.Border.primary)
+                    .overlay(theme.colors.border.primary)
 
                 SwiftUI.TextField(placeholder, text: $phoneNumber)
                     .disableAutocorrection(true)
@@ -91,7 +91,7 @@ struct PhoneNumberField: View {
                     ))
                     .textFieldStyle(.plain)
                     .frame(height: Platform.isMacOS ? 20 : 25)
-                    .padding([.top, .bottom, .leading], theme.Fields.style.padding)
+                    .padding([.top, .bottom, .leading], theme.components.field.padding)
                 #if os(iOS)
                     .autocapitalization(.none)
                     .keyboardType(.numberPad)
@@ -102,7 +102,7 @@ struct PhoneNumberField: View {
                         phoneNumber = ""
                     }
                     .tintColor(borderColor)
-                    .padding([.top, .bottom, .trailing], theme.Fields.style.padding)
+                    .padding([.top, .bottom, .trailing], theme.components.field.padding)
                 }
             }
             .focused($isFocused)
@@ -120,18 +120,18 @@ struct PhoneNumberField: View {
     private var foregroundColor: Color {
         switch validator.state {
         case .normal:
-            return theme.Colors.Foreground.secondary
+            return theme.colors.foreground.secondary
         case .error:
-            return theme.Colors.Foreground.error
+            return theme.colors.foreground.error
         }
     }
 
     private var borderColor: Color {
         switch validator.state {
         case .normal:
-            return theme.Colors.Border.interactive
+            return theme.colors.border.interactive
         case .error:
-            return theme.Colors.Border.error
+            return theme.colors.border.error
         }
     }
 
@@ -256,7 +256,7 @@ struct CountryCodeList: View {
                 .accessibilityLabel(Text(country.name))
             }
         }
-        .foregroundColor(theme.Colors.Foreground.primary)
+        .foregroundColor(theme.colors.foreground.primary)
         .listStyle(.plain)
     }
 

--- a/Sources/Authenticator/Views/Primitives/RadioButton.swift
+++ b/Sources/Authenticator/Views/Primitives/RadioButton.swift
@@ -41,7 +41,7 @@ struct RadioButton: View {
                     .font(.system(size: 24))
                     .foregroundColor(foregroundColor)
                     Text(label)
-                        .foregroundColor(theme.Colors.Foreground.primary)
+                        .foregroundColor(theme.colors.foreground.primary)
                     Spacer()
                 }
             }
@@ -50,9 +50,9 @@ struct RadioButton: View {
 
     private var foregroundColor: Color {
         if isSelected {
-            return theme.Colors.Background.interactive
+            return theme.colors.background.interactive
         }
 
-        return theme.Colors.Border.primary
+        return theme.colors.border.primary
     }
 }

--- a/Sources/Authenticator/Views/Primitives/TextField.swift
+++ b/Sources/Authenticator/Views/Primitives/TextField.swift
@@ -66,7 +66,7 @@ struct TextField: View {
                     }
                     .textFieldStyle(.plain)
                     .frame(height: Platform.isMacOS ? 20 : 25)
-                    .padding([.top, .bottom, .leading], theme.Fields.style.padding)
+                    .padding([.top, .bottom, .leading], theme.components.field.padding)
                 #if os(iOS)
                     .autocapitalization(.none)
                 #endif
@@ -76,7 +76,7 @@ struct TextField: View {
                         text = ""
                     }
                     .tintColor(clearButtonColor)
-                    .padding([.top, .bottom, .trailing], theme.Fields.style.padding)
+                    .padding([.top, .bottom, .trailing], theme.components.field.padding)
                 }
             }
         }
@@ -86,9 +86,9 @@ struct TextField: View {
         switch validator.state {
         case .normal:
             return isFocused ?
-                theme.Colors.Border.interactive : theme.Colors.Border.primary
+                theme.colors.border.interactive : theme.colors.border.primary
         case .error:
-            return theme.Colors.Border.error
+            return theme.colors.border.error
         }
     }
 

--- a/Sources/Authenticator/Views/SignInView.swift
+++ b/Sources/Authenticator/Views/SignInView.swift
@@ -212,6 +212,7 @@ public struct SignInHeader: View {
 
 /// Default footer for the ``SignInView``. It displays the navigation buttons
 public struct SignInFooter: View {
+    @Environment(\.authenticatorTheme) private var theme
     @Environment(\.authenticatorState) private var authenticatorState
     @Environment(\.authenticatorOptions) private var options
     @State private var authenticatorHidesSignUpButton = false
@@ -239,7 +240,7 @@ public struct SignInFooter: View {
     }
 
     public var body: some View {
-        HStack {
+        HStack(spacing: theme.components.authenticator.spacing.horizontal) {
             Button("authenticator.signIn.button.forgotPassword".localized()) {
                 authenticatorState.move(to: .resetPassword)
             }

--- a/Sources/Authenticator/Views/VerifyUserView.swift
+++ b/Sources/Authenticator/Views/VerifyUserView.swift
@@ -101,6 +101,6 @@ public struct VerifyUserHeader: View {
         DefaultHeader(
             title: "authenticator.verifyUser.title".localized()
         )
-        .font(theme.Fonts.title3)
+        .font(theme.fonts.title3)
     }
 }


### PR DESCRIPTION
**Description of changes**

This PR makes some changes to `AuthenticatorTheme` and its subtypes, based on the discussion with the UI team:
- Moving all variables names to `camelCase`
- Restructuring and renaming to closely match [existing Amplify UI theming solutions](https://github.com/aws-amplify/amplify-ui/tree/main/packages/ui/src/theme/tokens).
  ```
  AuthenticatorTheme
  ├── components
  │   └── authenticator
  │       └── ...
  │   └── button
  │       └── ...
  │   └── field
  │       └── ...
  │   └── alert
  │       └── ...
  │ 
  ├── fonts
  │   └── ...
  │ 
  ├── colors
  │   └── foreground
  │       └── ...
  │   └── background
  │       └── ...
  │   └── border
  │       └── ...
  │
  ```
- Removing the `Style` struct and integrating its properties into the corresponding components.
- Making all `padding` variables to be able to take different values for all edges. We can still just directly assign it to one value (i.e. all edges are the same) thanks to `ExpressibleByFloatLiteral` and `ExpressibleByIntegerLiteral`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
