### PR TITLE
fix: Setting the right username value when using EMAIL or PHONE_NUMBER as usernameAttributes in Cognito

### DIFF
--- a/Sources/Authenticator/Configuration/AmplifyConfiguration.swift
+++ b/Sources/Authenticator/Configuration/AmplifyConfiguration.swift
@@ -120,6 +120,17 @@ struct CognitoConfiguration {
         case username = "USERNAME"
         case email = "EMAIL"
         case phoneNumber = "PHONE_NUMBER"
+        
+        init?(from authUserAttributeKey: AuthUserAttributeKey) {
+            switch authUserAttributeKey {
+            case .email:
+                self = .email
+            case .phoneNumber:
+                self = .phoneNumber
+            default:
+                return nil
+            }
+        }
     }
 
     enum SignUpAttribute: String, Decodable {

--- a/Sources/Authenticator/States/SignUpState.swift
+++ b/Sources/Authenticator/States/SignUpState.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 /// The state observed by the Sign Up content view, representing the ``Authenticator`` is in the ``AuthenticatorStep/signUp`` step.
 public class SignUpState: AuthenticatorBaseState {
-    /// The Sign Up ``Field``s that are be displayed
+    /// The Sign Up ``Field``s that are displayed
     private(set) public var fields: [Field] = []
 
     /// Attempts to confirm the new password using the provided values.
@@ -36,6 +36,10 @@ public class SignUpState: AuthenticatorBaseState {
                     attributes.append(
                         AuthUserAttribute(key, value: field.value)
                     )
+                    // Check if the current AuthUserAttribute is defined to be the usernameAttribute in Cognito's config
+                    if configuration.usernameAttribute == CognitoConfiguration.UsernameAttribute(from: key) {
+                        username = field.value
+                    }
                 }
             }
         }

--- a/Tests/AuthenticatorTests/Mocks/MockAuthenticationService.swift
+++ b/Tests/AuthenticatorTests/Mocks/MockAuthenticationService.swift
@@ -69,9 +69,12 @@ class MockAuthenticationService: AuthenticationService {
     // MARK: - Sign Up
 
     var signUpCount = 0
+    var signUpParams: (username: String, password: String?)? = nil
     var mockedSignUpResult: AuthSignUpResult?
     func signUp(username: String, password: String?, options: AuthSignUpRequest.Options?) async throws -> AuthSignUpResult {
         signUpCount += 1
+        signUpParams = (username, password)
+        
         if let mockedSignUpResult = mockedSignUpResult {
             return mockedSignUpResult
         }

--- a/Tests/AuthenticatorTests/States/SignUpStateTests.swift
+++ b/Tests/AuthenticatorTests/States/SignUpStateTests.swift
@@ -62,7 +62,29 @@ class SignUpStateTests: XCTestCase {
             await task.value
         }
     }
+    
+    func testSignUp_withEmailAsUsernameAttribute_shouldSetEmailAsUsername() async {
+        authenticatorState.configuration.usernameAttributes = [.email]
+        await state.configure(with: [.email()])
 
+        let emailField = await state.fields.first(where: {$0.field.attributeType == .email})
+        emailField?.value = "email@email.com"
+        
+        try? await state.signUp()
+        XCTAssertEqual(authenticationService.signUpParams?.username, emailField?.value)
+    }
+    
+    func testSignUp_withPhoneNumberAsUsernameAttribute_shouldSetPhoneAsUsername() async {
+        authenticatorState.configuration.usernameAttributes = [.phoneNumber]
+        await state.configure(with: [.phoneNumber()])
+
+        let phoneNumberField = await state.fields.first(where: {$0.field.attributeType == .phoneNumber})
+        phoneNumberField?.value = "+12345678910"
+        
+        try? await state.signUp()
+        XCTAssertEqual(authenticationService.signUpParams?.username, phoneNumberField?.value)
+    }
+    
     func testConfigure_withFields_shouldPopulateFields_addingVerificationMechanism() {
         authenticatorState.configuration.verificationMechanisms = [
             .email,


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-amplify/amplify-ui-swift-authenticator/issues/17

**Description of changes:**
When the using `EMAIL` or `PHONE_NUMBER` as `usernameAttributes` in Cognito's configuration, the Authenticator was not properly using it as a `username` when calling `Amplify.Auth.signUp(username:password:)`.

This PR fixes that by grabbing the right value from the list of attributes when it applies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
