### PR TITLE
feat: Adding dialling code picker to PhoneNumberField

### DIFF
--- a/Sources/Authenticator/Utilities/RegionUtils.swift
+++ b/Sources/Authenticator/Utilities/RegionUtils.swift
@@ -17,7 +17,7 @@ struct Region: Equatable, Hashable {
         self.name = name
         self.code = code
         self.callingCode = callingCode
-        let base: UInt32 = 127397
+        let base = UnicodeScalar("🇦").value - UnicodeScalar("A").value
         let scalarView = String.UnicodeScalarView(code.unicodeScalars.compactMap {
             Unicode.Scalar(base + $0.value)
         })

--- a/Sources/Authenticator/Views/Primitives/PhoneNumberField.swift
+++ b/Sources/Authenticator/Views/Primitives/PhoneNumberField.swift
@@ -159,39 +159,6 @@ struct CallingCodeField: View {
     private let maxCallingCodeLength = 4
 
     var body: some View {
-        SwiftUI.TextField(
-            "authenticator.field.diallingCode.placeholder".localized(),
-            text: $callingCode
-        )
-        .focused($isFocused)
-        .onChange(of: callingCode) { text in
-            if text.isEmpty {
-                callingCode = "+"
-            } else if !text.hasPrefix("+") {
-                var updated = text
-                updated.removeAll(where: { $0 == "+" })
-                callingCode = "+\(updated)"
-            } else if text.count > maxCallingCodeLength {
-                callingCode = String(text.prefix(maxCallingCodeLength))
-            }
-        }
-        .onChange(of: isFocused) { isFocused in
-            if !isFocused, callingCode == "+" {
-                callingCode = defaultCallingCode
-            }
-        }
-        .multilineTextAlignment(.center)
-        .accessibilityLabel(Text(
-            "authenticator.field.diallingCode.label".localized()
-        ))
-        .textFieldStyle(.plain)
-        .frame(width: 55)
-    #if os(iOS)
-        .keyboardType(.numberPad)
-    #endif
-    }
-
-    private var callingCodePicker: some View {
         SwiftUI.Button(
             action: {
                 isShowingList = true
@@ -211,6 +178,10 @@ struct CallingCodeField: View {
                 allRegionsContent
             }
         }
+        .accessibilityLabel(Text(
+            "authenticator.field.diallingCode.label".localized()
+        ))
+        .frame(width: 55)
     }
 
     private var allRegionsContent: some View {
@@ -253,7 +224,8 @@ struct CallingCodeField: View {
                     }
                 )
                 .buttonStyle(.borderless)
-                .accessibilityLabel(Text(region.name))
+                .accessibilityLabel(Text("\(region.name), \(region.callingCode)"))
+                .accessibilityRemoveTraits(.isButton)
             }
         }
         .foregroundColor(theme.colors.foreground.primary)


### PR DESCRIPTION
**Description of changes:**

- Instead of having to manually type a region's dialling code, we now show a sheet with a list of regions, their flags and dialling codes, allowing to search within it

  <img width="170" alt="Screenshot 2023-05-16 at 14 24 23" src="https://github.com/aws-amplify/amplify-ui-swift-authenticator/assets/97059974/12a12722-1a33-4f3f-b63d-87941dd63722">


- Replacing the hardcoded `127397` with a proper calculated value when converting the region code to its flag emoji.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
