### PR TITLE
fix: Fixing the sorting function used in the list of regions

### DIFF
--- a/Sources/Authenticator/Utilities/RegionUtils.swift
+++ b/Sources/Authenticator/Utilities/RegionUtils.swift
@@ -62,7 +62,9 @@ class RegionUtils {
             }
         }
 
-        return regions.sorted(by: { $0.name < $1.name })
+        return regions.sorted(by: {
+            $0.name.compare($1.name, locale: locale) == .orderedAscending
+        })
     }()
 
     var currentCallingCode: String {


### PR DESCRIPTION
**Description of changes:**

Using `String.compare(_:locale:) == .orderedAscending` instead of just `<` so that accented vowels are properly sorted.

E.g.: Following an alphabetical order, "Åland Islands" should be displayed before than "Bahamas". However:

```swift
"Åland Islands" < "Bahamas" // false
"Åland Islands".compare("Bahamas", locale: Locale.current) == .orderedAscending // true
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
