### PR TITLE
feat: Improving the implementation of DatePicker

### DIFF
--- a/Sources/Authenticator/Models/SignUpField.swift
+++ b/Sources/Authenticator/Models/SignUpField.swift
@@ -308,6 +308,7 @@ public extension SignUpField where Self == BaseSignUpField {
     /// A date-based field associated with the given attribute key
     /// - Parameter key: The `AuthUserAttributeKey`
     /// - Parameter label: The label that is displayed along the field
+    /// - Parameter placeholder: The placeholder that is displayed in the field
     /// - Parameter isRequired: Whether the view will require a date to be entered before proceeding. Defaults to false.
     /// - Parameter minDate: The minimum date this field's value can be set to. Defaults to nil
     /// - Parameter maxDate: The maximum date this field's value can be set to. Defaults to nil
@@ -315,6 +316,7 @@ public extension SignUpField where Self == BaseSignUpField {
     static func date(
         key: AuthUserAttributeKey,
         label: String,
+        placeholder: String,
         isRequired: Bool = false,
         minDate: Date? = nil,
         maxDate: Date? = nil,
@@ -322,7 +324,7 @@ public extension SignUpField where Self == BaseSignUpField {
     ) -> SignUpField {
         return signUpField(
             label: label,
-            placeholder: "",
+            placeholder: placeholder,
             isRequired: isRequired,
             attributeType: .custom(attributeKey: key),
             inputType: .date,

--- a/Sources/Authenticator/Resources/en.lproj/Localizable.strings
+++ b/Sources/Authenticator/Resources/en.lproj/Localizable.strings
@@ -15,6 +15,7 @@
 "authenticator.imageButton.open" = "Open";
 "authenticator.imageButton.showPassword" = "Show password";
 "authenticator.imageButton.hidePassword" = "Hide password";
+"authenticator.imageButton.calendar" = "Calendar";
 
 "authenticator.field.username.label" = "Username";
 "authenticator.field.username.placeholder" = "Enter your username";

--- a/Sources/Authenticator/Views/Internal/SignUpInputField.swift
+++ b/Sources/Authenticator/Views/Internal/SignUpInputField.swift
@@ -52,6 +52,7 @@ struct SignUpInputField: View {
                 DatePicker(
                     field.label,
                     text: $field.value,
+                    placeholder: field.placeholder,
                     validator: validator
                 )
             case .phoneNumber:

--- a/Sources/Authenticator/Views/Primitives/ImageButton.swift
+++ b/Sources/Authenticator/Views/Primitives/ImageButton.swift
@@ -55,6 +55,8 @@ struct ImageButton: View {
             return "authenticator.imageButton.showPassword".localized()
         case .hidePassword:
             return "authenticator.imageButton.hidePassword".localized()
+        case .calendar:
+            return "authenticator.imageButton.calendar".localized()
         }
     }
 }
@@ -66,5 +68,6 @@ extension ImageButton {
         case open = "chevron.down.circle"
         case showPassword = "eye.fill"
         case hidePassword = "eye.slash.fill"
+        case calendar = "calendar"
     }
 }


### PR DESCRIPTION
**Description of changes:**

Re-writing the implementation of the **DatePicker** so that it looks more consistent with other Authenticator fields, and with how Apple deals with dates in native apps (Calendar, Reminders, etc).

Changes:
- Added support for a `placeholder`, which is shown when no date is seleceted
- When either the field or the 🗓️ button are tapped, a native `DatePicker` is revealed that allows to select a date
- The **ⓧ** button appears when a date is selected, which allows to remove the date.

| **Dev-Preview** | **Release** |
|-----------------|-------------|
|![old](https://github.com/aws-amplify/amplify-ui-swift-authenticator/assets/97059974/6af89de9-4d5c-453e-938e-01b6de347600) |![new](https://github.com/aws-amplify/amplify-ui-swift-authenticator/assets/97059974/1006d0ba-ad0a-4391-b75f-0c910accc2b3)|

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
