### PR TITLE
fix: Xcode 15 beta compilation error

### DIFF
--- a/Sources/Authenticator/Views/Internal/SignUpInputField.swift
+++ b/Sources/Authenticator/Views/Internal/SignUpInputField.swift
@@ -74,13 +74,13 @@ struct SignUpInputField: View {
         VStack(alignment: .leading) {
             AnyView(
                 field.content($field.value)
-                    .onChange(of: self.field.value) { _ in
-                        validator.validate()
-                    }
-                    .onAppear {
-                        validator.value = $field.value
-                    }
             )
+            .onChange(of: self.field.value) { _ in
+                validator.validate()
+            }
+            .onAppear {
+                validator.value = $field.value
+            }
             if case .error(let message) = validator.state, let errorMessage = message {
                 AnyView(
                     field.errorContent(errorMessage)


### PR DESCRIPTION
*Description of changes:*

Fixes a compilation error when compiling with Xcode 15 beta (15A5160n).

Error on line 75 of `SignUpInputField.swift`, `Type 'any View' cannot conform to 'View'`. It seems that for some reason the `AnyView` initializer doesn't like the return type of `onChange(of:)` in this context anymore. Moving the `onChange(of:)` and `onAppear` modifiers outside of the `AnyView` resolves the error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
