### PR TITLE
fix: Fixing issues with Sign Up fields

### DIFF
--- a/Sources/Authenticator/Constants/ComponentInformation.swift
+++ b/Sources/Authenticator/Constants/ComponentInformation.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 public class ComponentInformation {
-    public static let version = "1.0.0-dev-preview"
+    public static let version = "1.0.1"
     public static let name = "amplify-ui-swift-authenticator"
 }

--- a/Sources/Authenticator/Views/Primitives/PhoneNumberField.swift
+++ b/Sources/Authenticator/Views/Primitives/PhoneNumberField.swift
@@ -59,8 +59,10 @@ struct PhoneNumberField: View {
                 CallingCodeField(callingCode: $callingCode)
                     .foregroundColor(foregroundColor)
                     .focused($focusedField, equals: .callingCode)
-                    .onChange(of: callingCode) { text in
-                        self.text = "\(text)\(phoneNumber)"
+                    .onChange(of: callingCode) { code in
+                        if !phoneNumber.isEmpty {
+                            text = "\(code)\(phoneNumber)"
+                        }
                     }
 
                 Divider()


### PR DESCRIPTION
**Description of changes:**

This PR fixes the following issues on fields that are displayed in the Sign Up view:
 - Removes any duplicated field in the array provided to `configure(with signUpFields:)`
 - Avoids attempting to save an incomplete phone number if only the calling code is selected.

I'm also updating the `ComponentInformation.version`, which was still using the old `dev-preview` value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
