### PR TITLE
fix(DatePicker): Fixing the format used to parse the date into a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+## 1.0.3 (2023-08-17)
+
+### Bug Fixes
+- Fixing wrong date format being submitted when displaying `SignUpField` of type `date` (See [#31](https://github.com/aws-amplify/amplify-ui-swift-authenticator/pull/31))
+
+## 1.0.2 (2023-07-25)
+
+### Misc. Updates
+- Pinning the Amplify version up to 2.15.x
+
+## 1.0.1 (2023-06-15)
+
+### Bug Fixes
+- Fixing issues with Sign Up fields (See [#25](https://github.com/aws-amplify/amplify-ui-swift-authenticator/pull/25)).
+  - Removing duplicated fields in the array provided to `Authenticator.signUpFields(_:)`
+  - Preventing fields of type `.phoneNumber` from saving an incomplete phone number if only the dialling code is set.
+- Fixing Xcode 15 beta compilation error (See [#24](https://github.com/aws-amplify/amplify-ui-swift-authenticator/pull/24), thanks @RowbotNZ!)
+
+
+## 1.0.0 (2023-05-24)
+
+### Initial release of Amplify UI Authenticator for Swift UI
+
+Amplify Authenticator provides a complete drop-in implementation of an authentication flow for your application using [Amplify Authentication](https://docs.amplify.aws/lib/auth/getting-started/q/platform/ios/).
+
+More information on setting up and using the component is in the [documentation](https://ui.docs.amplify.aws/swift/connected-components/authenticator).

--- a/Sources/Authenticator/Constants/ComponentInformation.swift
+++ b/Sources/Authenticator/Constants/ComponentInformation.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 public class ComponentInformation {
-    public static let version = "1.0.2"
+    public static let version = "1.0.3"
     public static let name = "amplify-ui-swift-authenticator"
 }

--- a/Sources/Authenticator/Views/Primitives/DatePicker.swift
+++ b/Sources/Authenticator/Views/Primitives/DatePicker.swift
@@ -22,7 +22,11 @@ struct DatePicker: View {
     @Binding private var text: String
     private let label: String
     private let placeholder: String
-    private let formatter = ISO8601DateFormatter()
+    private var formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = .withFullDate
+        return formatter
+    }()
 
     init(_ label: String,
          text: Binding<String>,


### PR DESCRIPTION
### Issue
- https://github.com/aws-amplify/amplify-ui-swift-authenticator/issues/30

### Description of changes

When a `DatePicker` field was used (e.g. for the `birthDate` sign up field), the `ISO8601DateFormatter` that is used to parse the Date back to a String by defaults includes the time information as well.

This value was then rejected by Cognito as invalid, as they expect the date to be
> represented as an [ISO 8601:2004](https://openid.net/specs/openid-connect-core-1_0.html#ISO8601-2004) [ISO8601‑2004] `YYYY-MM-DD` format

This PR fixes this issue by setting the `.withFullDate` format options, which results in only the date being parsed to a string.

Additionally, I'm adding a `CHANGELOG.md` file with the past changes.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
