### PR TITLE
fix: Adding missing label when displaying a `.custom()` Sign Up field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.4 (2023-08-22)
+### Bug Fixes
+- Adding missing label when displaying a `.custom()` Sign Up field.
+
 ## 1.0.3 (2023-08-17)
 
 ### Bug Fixes

--- a/Sources/Authenticator/Constants/ComponentInformation.swift
+++ b/Sources/Authenticator/Constants/ComponentInformation.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 public class ComponentInformation {
-    public static let version = "1.0.3"
+    public static let version = "1.0.4"
     public static let name = "amplify-ui-swift-authenticator"
 }

--- a/Sources/Authenticator/Views/Internal/SignUpInputField.swift
+++ b/Sources/Authenticator/Views/Internal/SignUpInputField.swift
@@ -71,7 +71,16 @@ struct SignUpInputField: View {
     }
 
     @ViewBuilder func customView(for field: CustomSignUpField) -> some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: theme.components.field.spacing.vertical) {
+            if let label = field.label {
+                HStack {
+                    SwiftUI.Text(label)
+                        .foregroundColor(foregroundColor)
+                        .font(theme.fonts.body)
+                        .accessibilityHidden(true)
+                    Spacer()
+                }
+            }
             AnyView(
                 field.content($field.value)
             )
@@ -86,9 +95,18 @@ struct SignUpInputField: View {
                     field.errorContent(errorMessage)
                         .font(theme.fonts.subheadline)
                 )
-                    .foregroundColor(borderColor)
-                    .transition(options.contentTransition)
+                .foregroundColor(borderColor)
+                .transition(options.contentTransition)
             }
+        }
+    }
+    
+    private var foregroundColor: Color {
+        switch validator.state {
+        case .normal:
+            return theme.colors.foreground.secondary
+        case .error:
+            return theme.colors.foreground.error
         }
     }
 


### PR DESCRIPTION
**Description of changes:**

If a `label` was provided when creating a `.custom(...)` sign up field, it was never being displayed when rendered.

This PR fixes that. I'm also setting the `spacing` in the field's `Vstack` to match the other components.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
