### PR TITLE
fix(SignUpAttribute): Fixing required sign up attributes being rendered as optional

### DIFF
--- a/Sources/Authenticator/Models/SignUpAttribute.swift
+++ b/Sources/Authenticator/Models/SignUpAttribute.swift
@@ -188,3 +188,16 @@ extension CognitoConfiguration.SignUpAttribute {
         }
     }
 }
+
+extension CognitoConfiguration.UsernameAttribute {
+    var asSignUpAttribute: SignUpAttribute {
+        switch self {
+        case .username:
+            return .username
+        case .email:
+            return .email
+        case .phoneNumber:
+            return .phoneNumber
+        }
+    }
+}

--- a/Sources/Authenticator/Models/SignUpField.swift
+++ b/Sources/Authenticator/Models/SignUpField.swift
@@ -19,7 +19,7 @@ public protocol SignUpField {
 public struct BaseSignUpField: SignUpField {
     public let label: String
     public let placeholder: String
-    public let isRequired: Bool
+    internal(set) public var isRequired: Bool
     public let attributeType: SignUpAttribute
     public let validator: FieldValidator?
     let inputType: InputType
@@ -32,23 +32,23 @@ public struct BaseSignUpField: SignUpField {
         inputType: InputType = .text,
         validator: FieldValidator? = nil
     ) {
-        if isRequired {
-            self.label = label
-        } else {
-            self.label = "authenticator.field.label.optional".localized(using: label)
-        }
+        self.label = label
         self.placeholder = placeholder
         self.isRequired = isRequired
         self.attributeType = attributeType
         self.inputType = inputType
         self.validator = validator
     }
+
+    var displayedLabel: String {
+        return isRequired ? label : "authenticator.field.label.optional".localized(using: label)
+    }
 }
 
 /// A field that is displayed using a provided custom View
 public struct CustomSignUpField: SignUpField {
     public let label: String?
-    public let isRequired: Bool
+    internal(set) public var isRequired: Bool
     public let attributeType: SignUpAttribute
     public let validator: FieldValidator?
     public let content: (Binding<String>) -> any View
@@ -68,6 +68,11 @@ public struct CustomSignUpField: SignUpField {
         self.validator = validator
         self.content = content
         self.errorContent = errorContent
+    }
+
+    var displayedLabel: String? {
+        guard let label = label else { return nil }
+        return isRequired ? label : "authenticator.field.label.optional".localized(using: label)
     }
 }
 

--- a/Sources/Authenticator/Views/Internal/SignUpInputField.swift
+++ b/Sources/Authenticator/Views/Internal/SignUpInputField.swift
@@ -36,28 +36,28 @@ struct SignUpInputField: View {
             switch field.inputType {
             case .text:
                 TextField(
-                    field.label,
+                    field.displayedLabel,
                     text: $field.value,
                     placeholder: field.placeholder,
                     validator: validator
                 )
             case .password:
                 PasswordField(
-                    field.label,
+                    field.displayedLabel,
                     text: $field.value,
                     placeholder: field.placeholder,
                     validator: validator
                 )
             case .date:
                 DatePicker(
-                    field.label,
+                    field.displayedLabel,
                     text: $field.value,
                     placeholder: field.placeholder,
                     validator: validator
                 )
             case .phoneNumber:
                 PhoneNumberField(
-                    field.label,
+                    field.displayedLabel,
                     text: $field.value,
                     placeholder: field.placeholder,
                     validator: validator
@@ -72,7 +72,7 @@ struct SignUpInputField: View {
 
     @ViewBuilder func customView(for field: CustomSignUpField) -> some View {
         VStack(alignment: .leading, spacing: theme.components.field.spacing.vertical) {
-            if let label = field.label {
+            if let label = field.displayedLabel {
                 HStack {
                     SwiftUI.Text(label)
                         .foregroundColor(foregroundColor)
@@ -92,11 +92,12 @@ struct SignUpInputField: View {
             }
             if case .error(let message) = validator.state, let errorMessage = message {
                 AnyView(
-                    field.errorContent(errorMessage)
+                    field.errorContent(String(format: errorMessage, field.label ?? "authenticator.validator.field".localized()))
                         .font(theme.fonts.subheadline)
                 )
-                .foregroundColor(borderColor)
+                .foregroundColor(foregroundColor)
                 .transition(options.contentTransition)
+                .accessibilityHidden(true)
             }
         }
     }
@@ -107,15 +108,6 @@ struct SignUpInputField: View {
             return theme.colors.foreground.secondary
         case .error:
             return theme.colors.foreground.error
-        }
-    }
-
-    private var borderColor: Color {
-        switch validator.state {
-        case .normal:
-            return theme.colors.border.primary
-        case .error:
-            return theme.colors.border.error
         }
     }
 }


### PR DESCRIPTION
**Issue**
- https://github.com/aws-amplify/amplify-ui-swift-authenticator/issues/33

**Description of changes:**

The `signUpAttributes` array in the Amplify configuration lists all the **required** attributes in the Cognito User Pool, but the Authenticator was not treating them as such.

This PR makes the following changes:
- Ensures that all attributes in `signupAttributes` are marked as **required**
  - Tweaking `SignUpState.Field`, `BaseSignUpField` and `CustomSignUpField` in order to support this, but with no public API change.
- When the customer provides sign up fields, we now make the following validations:
  - That required fields are marked as such (e.g. if a user sets a `birthDate(isRequired: false)` but `BIRTHDATE` is in `signUpAttributes`, we're going to overwrite it as required).
  - That all `signupAttributes` and `verificationMechanisms` are displayed, even if the user did not provide them.
  - That a field for the `usernameAttribute` is displayed. If the user does not provide one, we'll show it at the top.
- Fixes the error message text and colour when a `.custom(label: "x", isRequired: true)` field is provided and fails its validation.
- Prevents unnecessary iterations through the sign up fields in order to find matches with the configuration's attributes, by relying on a `Set` instead. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
