### PR TITLE
fix: Fixing DatePicker and SignUpContent issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.5 (2023-08-31)
+
+### Bug Fixes
+- Fixing required Sign Up attributes being displayed as optionals
+- Fixing Sign Up fields not being populated when providing a `signUpContent`
+- Fixing DatePicker being interactable while invisible, plus not displaying previous dates.
+
 ## 1.0.4 (2023-08-22)
 ### Bug Fixes
 - Adding missing label when displaying a `.custom()` Sign Up field.

--- a/Sources/Authenticator/Authenticator.swift
+++ b/Sources/Authenticator/Authenticator.swift
@@ -310,6 +310,10 @@ public struct Authenticator<LoadingContent: View,
             confirmResetPasswordContent
         case .signUp:
             signUpContent
+                .onAppear {
+                    guard let state = signUpState, state.fields.isEmpty else { return }
+                    state.configure(with: viewModifiers.signUpFields)
+                }
         case .confirmSignUp:
             confirmSignUpContent
         case .verifyUser:
@@ -336,6 +340,10 @@ public struct Authenticator<LoadingContent: View,
         for contentState in contentStates.allObjects {
             contentState.configure(with: state)
         }
+    }
+    
+    private var signUpState: SignUpState? {
+        contentStates.allObjects.compactMap({ $0 as? SignUpState }).first
     }
 }
 

--- a/Sources/Authenticator/Constants/ComponentInformation.swift
+++ b/Sources/Authenticator/Constants/ComponentInformation.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 public class ComponentInformation {
-    public static let version = "1.0.4"
+    public static let version = "1.0.5"
     public static let name = "amplify-ui-swift-authenticator"
 }

--- a/Sources/Authenticator/Views/Primitives/DatePicker.swift
+++ b/Sources/Authenticator/Views/Primitives/DatePicker.swift
@@ -39,6 +39,10 @@ struct DatePicker: View {
             using: FieldValidators.none
         )
         self.validator.value = text
+        if let selectedDate = formatter.date(from: text.wrappedValue) {
+            self._selectedDate = .init(wrappedValue: selectedDate)
+            self._actualDate = .init(wrappedValue: selectedDate)
+        }
     }
 
 #if os(iOS)
@@ -88,6 +92,7 @@ struct DatePicker: View {
 
             createDatePicker(style: .graphical)
                 .frame(height: isShowingDatePicker ? nil : 0, alignment: .top)
+                .disabled(!isShowingDatePicker)
                 .clipped()
         }
     }
@@ -149,6 +154,7 @@ struct DatePicker: View {
         .onChange(of: selectedDate) { date in
             updateDate(date)
         }
+        .environment(\.timeZone, timeZone)
         .padding([.top, .bottom], theme.components.field.padding)
     }
 
@@ -203,13 +209,12 @@ struct DatePicker: View {
         guard let date = actualDate else {
             return placeholder
         }
-
-        return date.formatted(
-            .dateTime
-                .day()
-                .month()
-                .year()
-        )
+        
+        return date.formatted(Date.FormatStyle(
+            date: .abbreviated,
+            time: .omitted,
+            timeZone: timeZone
+        ))
     }
 
     private var placeholderColor: Color {
@@ -226,5 +231,9 @@ struct DatePicker: View {
         case .error:
             return theme.colors.border.error
         }
+    }
+    
+    private var timeZone: TimeZone {
+        TimeZone(secondsFromGMT: 0) ?? TimeZone.current
     }
 }


### PR DESCRIPTION
**Description of changes:**

This PR fixes the following issues:
- Setting a custom view on `signUpContent` does not populate the state's sign up fields.
  -  This is caused because the fields should be provided to the state when the view appears. This works on the default `SignUpView` because that one does it automatically, but we need to do it for custom views.
- `DatePicker` does not honour previously selected dates on reappear.
  - Setting the `actualDate` and `selectedDate` according to the `text`. Also setting the `TimeZone` explicitly to GMT to prevent discrepancies when parsing to and from strings.
- `DatePicker` is tappable when hidden.
  - TIL that setting the frame to `.zero` does not disable it from user input.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
