### PR TITLE
chore: Upgrading to Amplify 2.16+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.6 (2023-09-14)
+
+### Misc. Updates
+- Updating code to support Amplify 2.16+. However, **TOTP** workflows are **not** yet supported.
+
 ## 1.0.5 (2023-08-31)
 
 ### Bug Fixes

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/amplify-swift",
       "state" : {
-        "revision" : "3a795314e98434d063f68bf5dcf788124ac18406",
-        "version" : "2.15.1"
+        "revision" : "76ba8f1ead1cac4d53f313fb8d214c7bc5000551",
+        "version" : "2.17.1"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
       "state" : {
-        "revision" : "b036e83716789c13a3480eeb292b70caa54114f2",
-        "version" : "3.1.0"
+        "revision" : "c7ec93dcbbcd8abc90c74203937f207a7fcaa611",
+        "version" : "3.1.1"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
-        "version" : "1.5.2"
+        "revision" : "532d8b529501fb73a2455b179e0bbb6d49b652ed",
+        "version" : "1.5.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["Authenticator"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/aws-amplify/amplify-swift", "2.8.1"..<"2.16.0"),
+        .package(url: "https://github.com/aws-amplify/amplify-swift", from: "2.16.0"),
     ],
     targets: [
         .target(

--- a/Sources/Authenticator/Constants/ComponentInformation.swift
+++ b/Sources/Authenticator/Constants/ComponentInformation.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 public class ComponentInformation {
-    public static let version = "1.0.5"
+    public static let version = "1.0.6"
     public static let name = "amplify-ui-swift-authenticator"
 }

--- a/Sources/Authenticator/Models/AuthenticatorState.swift
+++ b/Sources/Authenticator/Models/AuthenticatorState.swift
@@ -58,7 +58,7 @@ public class AuthenticatorState: ObservableObject, AuthenticatorStateProtocol {
     }
 
     func setCurrentStep(_ step: Step) {
-        if case .error(let error) = step {
+        if case .error(let error) = self.step {
             log.error(error)
             log.error("Cannot move to \(step), the Authenticator is in error state.")
             return

--- a/Sources/Authenticator/States/AuthenticatorBaseState.swift
+++ b/Sources/Authenticator/States/AuthenticatorBaseState.swift
@@ -104,6 +104,12 @@ public class AuthenticatorBaseState: ObservableObject {
                 log.verbose("User has attributes pending verification: \(unverifiedAttributes)")
                 return .verifyUser(attributes: unverifiedAttributes)
             }
+        case .confirmSignInWithTOTPCode,
+             .continueSignInWithTOTPSetup(_):
+            log.error("The Authenticator does not yet support TOTP workflows.")
+            fallthrough
+        default:
+            throw AuthError.unknown("Unsupported next step: \(result.nextStep)", nil)
         }
     }
 

--- a/Tests/AuthenticatorTests/Mocks/MockAuthenticationService.swift
+++ b/Tests/AuthenticatorTests/Mocks/MockAuthenticationService.swift
@@ -177,6 +177,14 @@ class MockAuthenticationService: AuthenticationService {
     func forgetDevice(_ device: AuthDevice?, options: AuthForgetDeviceRequest.Options?) async throws {}
 
     func rememberDevice(options: AuthRememberDeviceRequest.Options?) async throws {}
+    
+    // MARK: - TOTP
+    
+    func setUpTOTP() async throws -> TOTPSetupDetails {
+        return .init(sharedSecret: "", username: "")
+    }
+    
+    func verifyTOTPSetup(code: String, options: VerifyTOTPSetupRequest.Options?) async throws {}
 }
 
 extension MockAuthenticationService {


### PR DESCRIPTION
**Description of changes:**

This PR unpins the Amplify version and makes the necessary code changes in order to compile.

**⚠️ Note:** TOTP support (introduced in [Amplify 2.16.0](https://github.com/aws-amplify/amplify-swift/releases/tag/2.16.0)) is **not** yet supported.

This PR also fixes an issue when calling `AuthenticatorState.setCurrentStep(_:)` when the current state is `.error`: The if condition was not checking the _current_ step value.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
