### PR TITLE
chore: Using new sendVerificationCode API.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/amplify-swift",
       "state" : {
-        "revision" : "76ba8f1ead1cac4d53f313fb8d214c7bc5000551",
-        "version" : "2.17.1"
+        "revision" : "3cc17d2635f743d32c68f4309836d30b49e970cf",
+        "version" : "2.26.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/amplify-swift-utils-notifications.git",
       "state" : {
-        "revision" : "f970384ad1035732f99259255cd2f97564807e41",
-        "version" : "1.1.0"
+        "revision" : "959eec669ba97c7d923b963c3e66ca8a0b2737f6",
+        "version" : "1.1.1"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
       "state" : {
-        "revision" : "c7ec93dcbbcd8abc90c74203937f207a7fcaa611",
-        "version" : "3.1.1"
+        "revision" : "a08684c5004e2049c29f57a5938beae9695a1ef7",
+        "version" : "3.1.2"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift",
       "state" : {
-        "revision" : "6feec6c3787877807aa9a00fad09591b96752376",
-        "version" : "0.6.1"
+        "revision" : "fd1756b6e5c9fd1a906edfb743f7cb64c2c98639",
+        "version" : "0.17.0"
       }
     },
     {
@@ -41,17 +41,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift.git",
       "state" : {
-        "revision" : "24bae88a2391fe75da8a940a544d1ef6441f5321",
-        "version" : "0.13.0"
+        "revision" : "387016f3e62119e9962da4357c63671c694554e6",
+        "version" : "0.31.0"
       }
     },
     {
       "identity" : "smithy-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/awslabs/smithy-swift",
+      "location" : "https://github.com/smithy-lang/smithy-swift",
       "state" : {
-        "revision" : "7b28da158d92cd06a3549140d43b8fbcf64a94a6",
-        "version" : "0.15.0"
+        "revision" : "ab999a9f0c972adcb350beda3c630a35697f7e8e",
+        "version" : "0.35.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
+        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
+        "version" : "1.1.0"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "532d8b529501fb73a2455b179e0bbb6d49b652ed",
-        "version" : "1.5.3"
+        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
+        "version" : "1.5.4"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MaxDesiatov/XMLCoder.git",
       "state" : {
-        "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
-        "version" : "0.17.1"
+        "revision" : "80b4a1646399b8e4e0ce80711653476a85bd5e37",
+        "version" : "0.17.0"
       }
     }
   ],

--- a/Sources/Authenticator/States/VerifyUserState.swift
+++ b/Sources/Authenticator/States/VerifyUserState.swift
@@ -37,7 +37,7 @@ public class VerifyUserState: AuthenticatorBaseState {
 
         do {
             log.verbose("Attempting to verify user attribute \(key)")
-            let result = try await authenticationService.resendConfirmationCode(
+            let result = try await authenticationService.sendVerificationCode(
                 forUserAttributeKey: key,
                 options: nil
             )

--- a/Tests/AuthenticatorTests/Mocks/MockAuthenticationService.swift
+++ b/Tests/AuthenticatorTests/Mocks/MockAuthenticationService.swift
@@ -122,6 +122,17 @@ class MockAuthenticationService: AuthenticationService {
         throw AuthenticatorError.error(message: "Unable to resend confirmation code for attribute")
     }
 
+    var sendVerificationCodeForAttributeCount = 0
+    var mockedSendVerificationCodeForAttributeResult: AuthCodeDeliveryDetails?
+    func sendVerificationCode(forUserAttributeKey userAttributeKey: AuthUserAttributeKey, options: AuthSendUserAttributeVerificationCodeRequest.Options?) async throws -> AuthCodeDeliveryDetails {
+        sendVerificationCodeForAttributeCount += 1
+        if let mockedSendVerificationCodeForAttributeResult = mockedSendVerificationCodeForAttributeResult {
+            return mockedSendVerificationCodeForAttributeResult
+        }
+
+        throw AuthenticatorError.error(message: "Unable to send verification code for attribute")
+    }
+
     var confirmUserAttributeCount = 0
     var mockedConfirmUserAttributeError: AuthenticatorError?
     func confirm(userAttribute: AuthUserAttributeKey, confirmationCode: String, options: AuthConfirmUserAttributeRequest.Options?) async throws {

--- a/Tests/AuthenticatorTests/States/VerifyUserStateTests.swift
+++ b/Tests/AuthenticatorTests/States/VerifyUserStateTests.swift
@@ -34,13 +34,13 @@ class VerifyUserStateTests: XCTestCase {
 
     func testVerifyUser_withSuccess_shouldSetNextStep() async throws {
         let destination = DeliveryDestination.email("email@email.com")
-        authenticationService.mockedResendConfirmationCodeForAttributeResult = .init(destination: destination)
+        authenticationService.mockedSendVerificationCodeForAttributeResult = .init(destination: destination)
         let task = Task { @MainActor in
             state.selectedField = .email
         }
         await task.value
         try await state.verifyUser()
-        XCTAssertEqual(authenticationService.resendConfirmationCodeForAttributeCount, 1)
+        XCTAssertEqual(authenticationService.sendVerificationCodeForAttributeCount, 1)
         XCTAssertEqual(authenticatorState.setCurrentStepCount, 1)
         let currentStep = try XCTUnwrap(authenticatorState.setCurrentStepValue)
         guard case .confirmVerifyUser(let attribute, let deliveryDetails) = currentStep else {


### PR DESCRIPTION
**Description of changes:**

This PR updates the `VerifyUserState` class to invoke Auth's new `sendVerificationCode` method instead of the now deprecated `resendConfirmationCode`.

Also adding the missing conformance to `MockAuthenticationService` so that the tests can compile and run.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
