### PR TITLE
fix: Auto-filled phone numbers contain characters rejected by Cognito

### DIFF
--- a/Sources/Authenticator/Views/Primitives/PhoneNumberField.swift
+++ b/Sources/Authenticator/Views/Primitives/PhoneNumberField.swift
@@ -60,8 +60,8 @@ struct PhoneNumberField: View {
                     .foregroundColor(foregroundColor)
                     .focused($focusedField, equals: .callingCode)
                     .onChange(of: callingCode) { code in
-                        if !phoneNumber.isEmpty {
-                            text = "\(code)\(phoneNumber)"
+                        if !numericPhoneNumber.isEmpty {
+                            text = "\(code)\(numericPhoneNumber)"
                         }
                     }
 
@@ -80,13 +80,11 @@ struct PhoneNumberField: View {
                             return
                         }
 
-                        if phoneNumber.isEmpty {
+                        if numericPhoneNumber.isEmpty {
                             // If the phone number is empty, we consider this to be an empty input regardless of the calling code, as that one is automatically populated
                             self.text = ""
                         } else {
-                            // Only numbers are allowed by the service, so remove other characters in the internally tracked full phone number
-                            let onlyNumbers = phoneNumber.filter("0123456789".contains)
-                            self.text = "\(callingCode)\(onlyNumbers)"
+                            self.text = "\(callingCode)\(numericPhoneNumber)"
                         }
 
                         if validator.state != .normal || !phoneNumber.isEmpty {
@@ -153,6 +151,10 @@ struct PhoneNumberField: View {
     private enum FieldType: Hashable {
         case callingCode
         case phoneNumber
+    }
+
+    private var numericPhoneNumber: String {
+        return phoneNumber.filter("0123456789".contains)
     }
 }
 


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/amplify-ui-swift-authenticator/issues/55

**Description of changes:**

[Cognito's expectations](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html#cognito-user-pools-standard-attributes) for a phone number is to be fully numerical except for the initial `+` sign. 
Although the **Authenticator's** Phone Number Field only shows the **numeric** keyboard for manual input, it's still possible to end up with non-numeric characters by using the **Auto-Fill** option, or simply by pasting a phone number from the clipboard.

The problem is that phone numbers are typically formatted in a way that include hyphens, spaces and parentheses (e.g. `+1 (123) 456-7890` instead of just `+11234567890`). So attempting to submit a phone number using any of these characters results in an error, as Cognito rejects the request.

While the easiest fix would be to remove any non-numeric character from being displayed in the Phone Number Field, I've decided to allow them on the customer facing field, but remove them from the internal field that is used when submitting to Cognito. The reasoning for this is that striping formatting would create a subpar experience for customers using Auto-Fill or pasting phone numbers.


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
