### PR TITLE
feat: remove dependency on amplifyconfiguration.json

### DIFF
--- a/Sources/Authenticator/Models/SignUpAttribute.swift
+++ b/Sources/Authenticator/Models/SignUpAttribute.swift
@@ -14,6 +14,7 @@ import SwiftUI
 #if canImport(UIKit)
 import UIKit
 #endif
+@_spi(InternalAmplifyConfiguration) import AWSCognitoAuthPlugin
 
 /// Represents to which Sign Up attribute a field is associated with.
 public enum SignUpAttribute: Equatable, Hashable {
@@ -145,7 +146,7 @@ public enum SignUpAttribute: Equatable, Hashable {
 #endif
 }
 
-extension CognitoConfiguration.VerificationMechanism {
+extension VerificationMechanism {
     var asSignUpAttribute: SignUpAttribute {
         switch self {
         case .email:
@@ -156,7 +157,7 @@ extension CognitoConfiguration.VerificationMechanism {
     }
 }
 
-extension CognitoConfiguration.SignUpAttribute {
+extension SignUpAttributeType {
     var asSignUpAttribute: SignUpAttribute {
         switch self {
         case .email:
@@ -189,7 +190,7 @@ extension CognitoConfiguration.SignUpAttribute {
     }
 }
 
-extension CognitoConfiguration.UsernameAttribute {
+extension UsernameAttribute {
     var asSignUpAttribute: SignUpAttribute {
         switch self {
         case .username:

--- a/Sources/Authenticator/Models/SignUpField.swift
+++ b/Sources/Authenticator/Models/SignUpField.swift
@@ -7,6 +7,7 @@
 
 import Amplify
 import SwiftUI
+@_spi(InternalAmplifyConfiguration) import AWSCognitoAuthPlugin
 
 /// Represents a field that is displayed in the Sign Up view
 public protocol SignUpField {
@@ -417,7 +418,7 @@ extension SignUpField where Self == BaseSignUpField {
     }
 
     static func signUpField(
-        from attribute: CognitoConfiguration.SignUpAttribute,
+        from attribute: SignUpAttributeType,
         isRequired: Bool
     ) -> SignUpField {
         switch attribute {
@@ -451,7 +452,7 @@ extension SignUpField where Self == BaseSignUpField {
     }
 
     static func signUpField(
-        from attribute: CognitoConfiguration.VerificationMechanism
+        from attribute: VerificationMechanism
     ) -> SignUpField {
         switch attribute {
         case .email:
@@ -462,7 +463,7 @@ extension SignUpField where Self == BaseSignUpField {
     }
 
     static func signUpField(
-        from attribute: CognitoConfiguration.UsernameAttribute
+        from attribute: UsernameAttribute
     ) -> SignUpField {
         switch attribute {
         case .username:

--- a/Sources/Authenticator/States/SignInState.swift
+++ b/Sources/Authenticator/States/SignInState.swift
@@ -6,7 +6,7 @@
 //
 
 import Amplify
-import AWSCognitoAuthPlugin
+@_spi(InternalAmplifyConfiguration) import AWSCognitoAuthPlugin
 import SwiftUI
 
 /// The state observed by the Sign In content view, representing the ``Authenticator`` is in the ``AuthenticatorStep/signIn`` step.

--- a/Sources/Authenticator/States/SignUpState.swift
+++ b/Sources/Authenticator/States/SignUpState.swift
@@ -8,6 +8,7 @@
 import Amplify
 import Foundation
 import SwiftUI
+@_spi(InternalAmplifyConfiguration) import AWSCognitoAuthPlugin
 
 /// The state observed by the Sign Up content view, representing the ``Authenticator`` is in the ``AuthenticatorStep/signUp`` step.
 public class SignUpState: AuthenticatorBaseState {
@@ -37,7 +38,7 @@ public class SignUpState: AuthenticatorBaseState {
                         AuthUserAttribute(key, value: field.value)
                     )
                     // Check if the current AuthUserAttribute is defined to be the usernameAttribute in Cognito's config
-                    if configuration.usernameAttribute == CognitoConfiguration.UsernameAttribute(from: key) {
+                    if configuration.usernameAttribute == UsernameAttribute(from: key) {
                         username = field.value
                     }
                 }

--- a/Sources/Authenticator/Utilities/FieldValidator.swift
+++ b/Sources/Authenticator/Utilities/FieldValidator.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+@_spi(InternalAmplifyConfiguration) import AWSCognitoAuthPlugin
 
 /// Represents an error associated with a Field, typically displayed beneath it.
 public typealias FieldError = CustomStringConvertible
@@ -41,7 +42,7 @@ public struct FieldValidators {
         /// ~~~
         public static let requiresSymbols: Self = .init(name: "requiresSymbols")
 
-        init(from policy: CognitoConfiguration.PasswordCharacterPolicy) {
+        init(from policy: PasswordCharacterPolicy) {
             switch policy {
             case .lowercase:
                 self = .requiresLowercase
@@ -157,7 +158,7 @@ public struct FieldValidators {
     }
 }
 
-extension Array where Element == CognitoConfiguration.PasswordCharacterPolicy {
+extension Array where Element == PasswordCharacterPolicy {
 
     func asPasswordCharactersPolicy() -> [FieldValidators.PasswordCharactersPolicy] {
         return compactMap { FieldValidators.PasswordCharactersPolicy(from: $0) }

--- a/Sources/Authenticator/Views/ConfirmResetPasswordView.swift
+++ b/Sources/Authenticator/Views/ConfirmResetPasswordView.swift
@@ -7,6 +7,7 @@
 
 import Amplify
 import SwiftUI
+@_spi(InternalAmplifyConfiguration) import AWSCognitoAuthPlugin
 
 /// Represents the content being displayed when the ``Authenticator`` is in the ``AuthenticatorStep/confirmResetPassword`` step.
 public struct ConfirmResetPasswordView<Header: View,
@@ -44,7 +45,7 @@ public struct ConfirmResetPasswordView<Header: View,
             using: { value in
                 let configuration = state.configuration.passwordProtectionSettings
                 return FieldValidators.password(
-                    minLength: configuration.minLength,
+                    minLength: configuration.minLength ?? 0,
                     characterPolicy: configuration.characterPolicy.asPasswordCharactersPolicy()
                 )(value)
             }

--- a/Sources/Authenticator/Views/ConfirmSignInWithNewPasswordView.swift
+++ b/Sources/Authenticator/Views/ConfirmSignInWithNewPasswordView.swift
@@ -7,6 +7,7 @@
 
 import Amplify
 import SwiftUI
+@_spi(InternalAmplifyConfiguration) import AWSCognitoAuthPlugin
 
 /// Represents the content being displayed when the ``Authenticator`` is in the ``AuthenticatorStep/confirmSignInWithNewPassword`` step.
 public struct ConfirmSignInWithNewPasswordView<Header: View,
@@ -40,7 +41,7 @@ public struct ConfirmSignInWithNewPasswordView<Header: View,
             using: { value in
                 let configuration = state.configuration.passwordProtectionSettings
                 return FieldValidators.password(
-                    minLength: configuration.minLength,
+                    minLength: configuration.minLength ?? 0,
                     characterPolicy: configuration.characterPolicy.asPasswordCharactersPolicy()
                 )(value)
             }

--- a/Sources/Authenticator/Views/ResetPasswordView.swift
+++ b/Sources/Authenticator/Views/ResetPasswordView.swift
@@ -7,6 +7,7 @@
 
 import Amplify
 import SwiftUI
+@_spi(InternalAmplifyConfiguration) import AWSCognitoAuthPlugin
 
 /// Represents the content being displayed when the ``Authenticator`` is in the ``AuthenticatorStep/resetPassword`` step.
 ///
@@ -75,7 +76,7 @@ public struct ResetPasswordView<Header: View,
     }
 
     @ViewBuilder private func createUsernameInput(
-        for usernameAttribute: CognitoConfiguration.UsernameAttribute
+        for usernameAttribute: UsernameAttribute
     ) -> some View {
         switch usernameAttribute {
         case .username:

--- a/Sources/Authenticator/Views/SignInView.swift
+++ b/Sources/Authenticator/Views/SignInView.swift
@@ -7,6 +7,7 @@
 
 import Amplify
 import SwiftUI
+@_spi(InternalAmplifyConfiguration) import AWSCognitoAuthPlugin
 
 /// Represents the content being displayed when the ``Authenticator`` is in the ``AuthenticatorStep/signIn`` step.
 ///
@@ -153,7 +154,7 @@ public struct SignInView<Header: View,
     }
 
     @ViewBuilder private func createUsernameInput(
-        for usernameAttribute: CognitoConfiguration.UsernameAttribute
+        for usernameAttribute: UsernameAttribute
     ) -> some View {
         switch usernameAttribute {
         case .username:

--- a/Sources/Authenticator/Views/SignUpView.swift
+++ b/Sources/Authenticator/Views/SignUpView.swift
@@ -7,6 +7,7 @@
 
 import Amplify
 import SwiftUI
+@_spi(InternalAmplifyConfiguration) import AWSCognitoAuthPlugin
 
 /// Represents the content being displayed when the ``Authenticator`` is in the ``AuthenticatorStep/signUp`` step.
 public struct SignUpView<Header: View,
@@ -199,7 +200,7 @@ extension SignUpView {
                     if case .password = field.attributeType {
                         let configuration = self.state.configuration.passwordProtectionSettings
                         return FieldValidators.password(
-                            minLength: configuration.minLength,
+                            minLength: configuration.minLength ?? 0,
                             characterPolicy: configuration.characterPolicy.asPasswordCharactersPolicy()
                         )(value)
                     } else if case .passwordConfirmation = field.attributeType, value != self.state.password {

--- a/Tests/AuthenticatorTests/Mocks/MockAuthenticatorState.swift
+++ b/Tests/AuthenticatorTests/Mocks/MockAuthenticatorState.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 @testable import Authenticator
+@_spi(InternalAmplifyConfiguration) import AWSCognitoAuthPlugin
 
 class MockAuthenticatorState: AuthenticatorStateProtocol {
     var authenticationService: AuthenticationService = MockAuthenticationService()

--- a/Tests/AuthenticatorTests/States/SignUpStateTests.swift
+++ b/Tests/AuthenticatorTests/States/SignUpStateTests.swift
@@ -8,6 +8,7 @@
 import Amplify
 @testable import Authenticator
 import XCTest
+@_spi(InternalAmplifyConfiguration) import AWSCognitoAuthPlugin
 
 class SignUpStateTests: XCTestCase {
     private var state: SignUpState!


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR includes the changes that no longer depend on `jsonConfiguration` to get the auth configuration values. This PR needs to be updated with a version upgrade on the Amplify dependency to get the `authConfiguration` changes at a minimum. It depends on this PR to be merged and released first: https://github.com/aws-amplify/amplify-swift/pull/3566

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
