### PR TITLE
fix(ConfirmSignUp): Updating the state's `deliveryDetails` property when a new code is sent

### DIFF
--- a/Sources/Authenticator/Authenticator.swift
+++ b/Sources/Authenticator/Authenticator.swift
@@ -245,6 +245,12 @@ public struct Authenticator<LoadingContent: View,
             }
         }
         .onReceive(state.$step) {
+            // Currently, the only Step that can transition to itself is `.confirmSignUp(deliveryDetails)`,
+            // when new delivery details are populated by requesting a new code.
+            // We don't want to re-draw the Authenticator on said situations, so ignore it.
+            guard $0.authenticatorStep != self.currentStep.authenticatorStep else {
+                return
+            }
             self.previousStep = self.currentStep
             self.currentStep = $0
         }

--- a/Sources/Authenticator/States/ConfirmSignUpState.swift
+++ b/Sources/Authenticator/States/ConfirmSignUpState.swift
@@ -65,6 +65,7 @@ public class ConfirmSignUpState: AuthenticatorBaseState {
             )
 
             setMessage(.info(message: localizedMessage(for: details)))
+            authenticatorState.setCurrentStep(.confirmSignUp(deliveryDetails: details))
         } catch {
             log.error("Unable to resend the Sign Up confirmation code")
             let authenticationError = self.error(for: error)


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/amplify-ui-swift-authenticator/issues/62

**Description of changes:**

When the Authenticator is in the `.confirmSignUp` step and a new confirmation code is sent through `state.sendCode()`, `state.deliveryDetails` was not updated with the new information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
