### PR TITLE
fix: Making `AuthenticatorState.move(to:)` public

### DIFF
--- a/Sources/Authenticator/Models/AuthenticatorState.swift
+++ b/Sources/Authenticator/Models/AuthenticatorState.swift
@@ -48,9 +48,16 @@ public class AuthenticatorState: ObservableObject, AuthenticatorStateProtocol {
         }
     }
 
-    func move(to initialStep: AuthenticatorInitialStep) {
+    /// Manually moves the Authenticator to an initial step
+    /// - Parameter initialStep: The desired ``AuthenticatorInitialStep``
+    public func move(to initialStep: AuthenticatorInitialStep) {
         if case .signedIn(_) = step {
             log.error("Cannot move to \(initialStep), the user is currently signed in. Call signOut first.")
+            return
+        }
+
+        guard step != .init(from: initialStep) else {
+            log.warn("Attempted to move to \(initialStep), but the Authenticator is already in that step.")
             return
         }
 

--- a/Sources/Authenticator/Models/AuthenticatorStep.swift
+++ b/Sources/Authenticator/Models/AuthenticatorStep.swift
@@ -28,7 +28,6 @@ public struct AuthenticatorInitialStep: Equatable {
 /// An `AuthenticatorStep` represents a "state" or "view" for the Authenticator component within its lifecycle.
 public struct AuthenticatorStep: Equatable {
     private let name: String
-    //private(set) public var state: State = .signedOut
 
     private init(_ name: String) {
         self.name = name


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/amplify-ui-swift-authenticator/issues/64

**Description of changes:**

`AuthenticatorState.move(to:)` was meant to be `public` in order to allow developers of customized views to navigate through the initial steps, but it was `internal` instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
