### PR TITLE
chore: Release 1.1.2 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.1.2 (2024-04-26)
+
+### Bug Fixes
+
+- **AuthenticatorState**: Making `move(to:)` public (#66)
+- **ConfirmSignUp**: Updating the state's `deliveryDetails` property when a new code is sent (#65)
+
 ## 1.1.1 (2024-03-11)
 
 ### Bug Fixes

--- a/Sources/Authenticator/Constants/ComponentInformation.swift
+++ b/Sources/Authenticator/Constants/ComponentInformation.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 public class ComponentInformation {
-    public static let version = "1.1.1"
+    public static let version = "1.1.2"
     public static let name = "amplify-ui-swift-authenticator"
 }


### PR DESCRIPTION
**Description of changes:**
Updating the CHANGELOG and the `ComponentInformation.version` property in preparation for release 1.1.2


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
