### PR TITLE
fix: Sign in fails when user is auto confirmed after sign up

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,9 +8,7 @@ on:
 
 jobs:
   unit-test-ios:
-
     runs-on: macos-latest
-
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Unit test Authenticator on iOS
@@ -24,15 +22,13 @@ jobs:
           cd ${{ github.workspace }}
           xcrun llvm-cov export -format="lcov" -instr-profile $pathCoverage Build/Build/Products/Debug-iphonesimulator/Authenticator.o > Authenticator-Coverage.lcov
       - name: Upload Report
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+        uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4.3.0
         with:
           flags: Authenticator
-          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   unit-test-macos:
-
     runs-on: macos-latest
-
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Unit test Authenticator on macOS

--- a/Sources/Authenticator/States/SignUpState.swift
+++ b/Sources/Authenticator/States/SignUpState.swift
@@ -51,10 +51,10 @@ public class SignUpState: AuthenticatorBaseState {
                 password: password,
                 options: .init(userAttributes: attributes)
             )
-            let nextStep = try await nextStep(for: result)
-            setBusy(false)
             credentials.username = username
             credentials.password = password
+            let nextStep = try await nextStep(for: result)
+            setBusy(false)
             authenticatorState.setCurrentStep(nextStep)
         } catch {
             log.error("Unable to Sign Up")


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/amplify-ui-swift-authenticator/issues/71

**Description of changes:**

When a Sign Up flows is successful, the Authenticator automatically determines the next action based on the result's `nextStep`.
If a user doesn't need confirmation, the next step will be `done`, in which case the Authenticator will attempt to automatically Sign In.

However, because the user credentials were not yet set, the sign in request failed because it provided empty values.

***Other changes***
- Fixing the upload of coverage by providing the Codecov Token.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
