### PR TITLE
fix: Displaying the correct message on connectivity errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.1.4 (2024-06-07)
+
+### Bug Fixes
+- **Authenticator**: Showing the proper message when there's connectivity issues (#82)
+
+### Misc. Updates
+- Updating code to support Amplify 2.35+. (#82)
+
 ## 1.1.3 (2024-06-04)
 
 ### Bug Fixes

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/amplify-swift",
       "state" : {
-        "revision" : "0e4dc695c4cd3c53d145b9f6498ad83004edae6d",
-        "version" : "2.34.4"
+        "revision" : "fa6ca64f42c3e4e72cf6b62c30bc45b2be7b05bc",
+        "version" : "2.35.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["Authenticator"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/aws-amplify/amplify-swift", "2.16.0"..<"2.35.0"),
+        .package(url: "https://github.com/aws-amplify/amplify-swift", from: "2.35.0"),
     ],
     targets: [
         .target(

--- a/Sources/Authenticator/Models/AuthenticatorState.swift
+++ b/Sources/Authenticator/Models/AuthenticatorState.swift
@@ -7,7 +7,7 @@
 
 import Amplify
 @_spi(InternalAmplifyPluginExtension) import AWSCognitoAuthPlugin
-@_spi(InternalAmplifyPluginExtension) import AWSPluginsCore
+@_spi(InternalAmplifyPluginExtension) import InternalAmplifyCredentials
 import Foundation
 
 /// An `ObservableObject` that represents the Authenticator's state

--- a/Sources/Authenticator/States/AuthenticatorBaseState.swift
+++ b/Sources/Authenticator/States/AuthenticatorBaseState.swift
@@ -213,6 +213,12 @@ public class AuthenticatorBaseState: ObservableObject {
             }
         }
 
+        // First check if the underlying error is a connectivity one
+        if isConnectivityError(error.underlyingError) {
+            log.verbose("The error is identified as a connectivity issue, displaying the corresponding localized string.")
+            return "authenticator.cognitoError.network".localized()
+        }
+
         guard let cognitoError = error.underlyingError as? AWSCognitoAuthError else {
             log.verbose("Unable to localize error that is not of type AWSCognitoAuthError")
             return nil
@@ -228,6 +234,20 @@ public class AuthenticatorBaseState: ObservableObject {
         
         log.verbose("No localizable string was found for error of type '\(cognitoError)'")
         return nil
+    }
+
+    private func isConnectivityError(_ error: Error?) -> Bool {
+        guard let error = error as? NSError else {
+            return false
+        }
+        let networkErrorCodes = [
+            NSURLErrorCannotFindHost,
+            NSURLErrorCannotConnectToHost,
+            NSURLErrorNetworkConnectionLost,
+            NSURLErrorDNSLookupFailed,
+            NSURLErrorNotConnectedToInternet
+        ]
+        return networkErrorCodes.contains(where: { $0 == error.code })
     }
 }
 


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/amplify-ui-swift-authenticator/issues/79

**Description of changes:**

This PR adds some logic to identify connectivity errors and display the proper error message, instead of defaulting to the generic unknown error.

*Additional changes:*
- Updated the code to support Amplify 2.35+ and update the code accordingly.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
