### PR TITLE
fix(Authenticator): Handling expired sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
+## 1.1.6 (2024-08-13)
+
+### Bug Fixes
+- **Authenticator**: Properly handling expired sessions when loading the component (#87)
+
 ## 1.1.5 (2024-07-02)
 
 ### Bug Fixes
-- **Authenticator**: Settting corner radius according to the theme (#84)
+- **Authenticator**: Setting corner radius according to the theme (#84)
 
 ## 1.1.4 (2024-06-07)
 

--- a/Sources/Authenticator/Configuration/AmplifyConfiguration.swift
+++ b/Sources/Authenticator/Configuration/AmplifyConfiguration.swift
@@ -106,11 +106,25 @@ struct AmplifyConfiguration {
             }
         }
 
+        var hasIdentityPool = false
+        if let cognitoConfiguration = configuration.value(at: "CredentialsProvider.CognitoIdentity.Default"),
+           case .string(let poolId) = cognitoConfiguration["PoolId"], !poolId.isEmpty {
+            hasIdentityPool = true
+        }
+
+        var hasUserPool = false
+        if let cognitoConfiguration = configuration.value(at: "CognitoUserPool.Default"),
+           case .string(let poolId) = cognitoConfiguration["PoolId"], !poolId.isEmpty {
+            hasUserPool = true
+        }
+
         self.cognito = CognitoConfiguration(
             usernameAttributes: usernameAttributes,
             signupAttributes: signUpAttributes,
             passwordProtectionSettings: passwordProtectionSettings,
-            verificationMechanisms: verificationMechanisms
+            verificationMechanisms: verificationMechanisms,
+            hasUserPool: hasUserPool,
+            hasIdentityPool: hasIdentityPool
         )
     }
 }
@@ -179,12 +193,18 @@ struct CognitoConfiguration {
         return .username
     }
 
+    var hasUserPool: Bool
+    var hasIdentityPool: Bool
+
     static var empty: CognitoConfiguration {
         .init(
             usernameAttributes: [],
             signupAttributes: [],
             passwordProtectionSettings: .init(minLength: 0, characterPolicy: []),
-            verificationMechanisms: [])
+            verificationMechanisms: [],
+            hasUserPool: false,
+            hasIdentityPool: false
+        )
     }
 }
 

--- a/Sources/Authenticator/Constants/ComponentInformation.swift
+++ b/Sources/Authenticator/Constants/ComponentInformation.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 public class ComponentInformation {
-    public static let version = "1.1.5"
+    public static let version = "1.1.6"
     public static let name = "amplify-ui-swift-authenticator"
 }

--- a/Tests/AuthenticatorTests/Mocks/MockAuthenticatorState.swift
+++ b/Tests/AuthenticatorTests/Mocks/MockAuthenticatorState.swift
@@ -15,7 +15,9 @@ class MockAuthenticatorState: AuthenticatorStateProtocol {
         usernameAttributes: [],
         signupAttributes: [],
         passwordProtectionSettings: .init(minLength: 0, characterPolicy: []),
-        verificationMechanisms: []
+        verificationMechanisms: [],
+        hasUserPool: true,
+        hasIdentityPool: true
     )
 
     var setCurrentStepCount = 0


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/amplify-ui-swift-authenticator/issues/86

**Description of changes:**

When a user session cannot be refreshed, `Amplify.Auth.fetchAuthSession()` will still return `isSignedIn: true`, but attempting to perform any operation that requires authentication will subsequently fail and ask the user to log in again.

This is a known thing within Amplify, but can be handled by the Authenticator by signing out the user if we detect their session has expired when the component is launched. 

This PR proposes validating that a session has valid identity ID and/or Cognito tokens, depending on what type of configuration the user is using:
- If they only have `CognitoIdentity`, only check for a valid `session.getIdentityId()
- If they only have `CognitoUserPool`, only check for valid `session.getCognitoTokens()`.
- If they have both, check for both `session.getIdentityId()` and `session.getCognitoTokens()`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
