### PR TITLE
fix(Authenticator): Allowing to only override the desired errors when invoking the errorMap functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.7 (2024-09-13)
+
+### Bug Fixes
+- **Authenticator**: Allowing to only override the desired errors when invoking the errorMap functions (#93)
+
 ## 1.1.6 (2024-08-13)
 
 ### Bug Fixes

--- a/Sources/Authenticator/Authenticator.swift
+++ b/Sources/Authenticator/Authenticator.swift
@@ -290,7 +290,7 @@ public struct Authenticator<LoadingContent: View,
 
     /// Sets a custom error mapping function for the `AuthError`s that are displayed
     /// - Parameter errorTransform: A closure that takes an `AuthError` and returns a ``AuthenticatorError`` that will be displayed.
-    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError) -> Self {
+    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError?) -> Self {
         for contentState in contentStates.allObjects {
             contentState.errorTransform = errorTransform
         }

--- a/Sources/Authenticator/Constants/ComponentInformation.swift
+++ b/Sources/Authenticator/Constants/ComponentInformation.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 public class ComponentInformation {
-    public static let version = "1.1.6"
+    public static let version = "1.1.7"
     public static let name = "amplify-ui-swift-authenticator"
 }

--- a/Sources/Authenticator/States/AuthenticatorBaseState.swift
+++ b/Sources/Authenticator/States/AuthenticatorBaseState.swift
@@ -23,7 +23,7 @@ public class AuthenticatorBaseState: ObservableObject {
 
     @ObservedObject var credentials: Credentials
 
-    var errorTransform: ((AuthError) -> AuthenticatorError)? = nil
+    var errorTransform: ((AuthError) -> AuthenticatorError?)? = nil
     private(set) var authenticatorState: AuthenticatorStateProtocol = .empty
 
     init(credentials: Credentials) {
@@ -183,8 +183,8 @@ public class AuthenticatorBaseState: ObservableObject {
             return .unknown(from: error)
         }
 
-        if let errorTransform = errorTransform {
-            return errorTransform(authError)
+        if let customError = errorTransform?(authError) {
+            return customError
         }
 
         if let localizedMessage = localizedMessage(for: authError) {

--- a/Sources/Authenticator/Views/ConfirmResetPasswordView.swift
+++ b/Sources/Authenticator/Views/ConfirmResetPasswordView.swift
@@ -135,7 +135,7 @@ public struct ConfirmResetPasswordView<Header: View,
 
     /// Sets a custom error mapping function for the `AuthError`s that are displayed
     /// - Parameter errorTransform: A closure that takes an `AuthError` and returns a ``AuthenticatorError`` that will be displayed.
-    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError) -> Self {
+    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError?) -> Self {
         state.errorTransform = errorTransform
         return self
     }

--- a/Sources/Authenticator/Views/ConfirmSignInWithCustomChallengeView.swift
+++ b/Sources/Authenticator/Views/ConfirmSignInWithCustomChallengeView.swift
@@ -42,7 +42,7 @@ public struct ConfirmSignInWithCustomChallengeView<Header: View,
 
     /// Sets a custom error mapping function for the `AuthError`s that are displayed
     /// - Parameter errorTransform: A closure that takes an `AuthError` and returns a ``AuthenticatorError`` that will be displayed.
-    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError) -> Self {
+    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError?) -> Self {
         state.errorTransform = errorTransform
         return self
     }

--- a/Sources/Authenticator/Views/ConfirmSignInWithMFACodeView.swift
+++ b/Sources/Authenticator/Views/ConfirmSignInWithMFACodeView.swift
@@ -48,7 +48,7 @@ public struct ConfirmSignInWithMFACodeView<Header: View,
 
     /// Sets a custom error mapping function for the `AuthError`s that are displayed
     /// - Parameter errorTransform: A closure that takes an `AuthError` and returns a ``AuthenticatorError`` that will be displayed.
-    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError) -> Self {
+    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError?) -> Self {
         state.errorTransform = errorTransform
         return self
     }

--- a/Sources/Authenticator/Views/ConfirmSignInWithNewPasswordView.swift
+++ b/Sources/Authenticator/Views/ConfirmSignInWithNewPasswordView.swift
@@ -111,7 +111,7 @@ public struct ConfirmSignInWithNewPasswordView<Header: View,
 
     /// Sets a custom error mapping function for the `AuthError`s that are displayed
     /// - Parameter errorTransform: A closure that takes an `AuthError` and returns a ``AuthenticatorError`` that will be displayed.
-    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError) -> Self {
+    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError?) -> Self {
         state.errorTransform = errorTransform
         return self
     }

--- a/Sources/Authenticator/Views/ConfirmSignInWithTOTPCodeView.swift
+++ b/Sources/Authenticator/Views/ConfirmSignInWithTOTPCodeView.swift
@@ -43,7 +43,7 @@ public struct ConfirmSignInWithTOTPView<Header: View,
 
     /// Sets a custom error mapping function for the `AuthError`s that are displayed
     /// - Parameter errorTransform: A closure that takes an `AuthError` and returns a ``AuthenticatorError`` that will be displayed.
-    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError) -> Self {
+    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError?) -> Self {
         state.errorTransform = errorTransform
         return self
     }

--- a/Sources/Authenticator/Views/ConfirmSignUpView.swift
+++ b/Sources/Authenticator/Views/ConfirmSignUpView.swift
@@ -98,7 +98,7 @@ public struct ConfirmSignUpView<Header: View,
 
     /// Sets a custom error mapping function for the `AuthError`s that are displayed
     /// - Parameter errorTransform: A closure that takes an `AuthError` and returns a ``AuthenticatorError`` that will be displayed.
-    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError) -> Self {
+    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError?) -> Self {
         state.errorTransform = errorTransform
         return self
     }

--- a/Sources/Authenticator/Views/ConfirmVerifyUserView.swift
+++ b/Sources/Authenticator/Views/ConfirmVerifyUserView.swift
@@ -82,7 +82,7 @@ public struct ConfirmVerifyUserView<Header: View,
 
     /// Sets a custom error mapping function for the `AuthError`s that are displayed
     /// - Parameter errorTransform: A closure that takes an `AuthError` and returns a ``AuthenticatorError`` that will be displayed.
-    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError) -> Self {
+    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError?) -> Self {
         state.errorTransform = errorTransform
         return self
     }

--- a/Sources/Authenticator/Views/ContinueSignInWithMFASelectionView.swift
+++ b/Sources/Authenticator/Views/ContinueSignInWithMFASelectionView.swift
@@ -89,7 +89,7 @@ public struct ContinueSignInWithMFASelectionView<Header: View,
     
     /// Sets a custom error mapping function for the `AuthError`s that are displayed
     /// - Parameter errorTransform: A closure that takes an `AuthError` and returns a ``AuthenticatorError`` that will be displayed.
-    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError) -> Self {
+    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError?) -> Self {
         state.errorTransform = errorTransform
         return self
     }

--- a/Sources/Authenticator/Views/ContinueSignInWithTOTPSetupView.swift
+++ b/Sources/Authenticator/Views/ContinueSignInWithTOTPSetupView.swift
@@ -120,7 +120,7 @@ public struct ContinueSignInWithTOTPSetupView<Header: View,
 
     /// Sets a custom error mapping function for the `AuthError`s that are displayed
     /// - Parameter errorTransform: A closure that takes an `AuthError` and returns a ``AuthenticatorError`` that will be displayed.
-    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError) -> Self {
+    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError?) -> Self {
         state.errorTransform = errorTransform
         return self
     }

--- a/Sources/Authenticator/Views/Internal/ConfirmSignInWithCodeView.swift
+++ b/Sources/Authenticator/Views/Internal/ConfirmSignInWithCodeView.swift
@@ -25,7 +25,7 @@ struct ConfirmSignInWithCodeView<Header: View,
         @ViewBuilder footerContent: () -> Footer = {
             EmptyView()
         },
-        errorTransform: ((AuthError) -> AuthenticatorError)? = nil,
+        errorTransform: ((AuthError) -> AuthenticatorError?)? = nil,
         mfaType: AuthenticatorMFAType
     ) {
         self.state = state

--- a/Sources/Authenticator/Views/ResetPasswordView.swift
+++ b/Sources/Authenticator/Views/ResetPasswordView.swift
@@ -113,7 +113,7 @@ public struct ResetPasswordView<Header: View,
 
     /// Sets a custom error mapping function for the `AuthError`s that are displayed
     /// - Parameter errorTransform: A closure that takes an `AuthError` and returns a ``AuthenticatorError`` that will be displayed.
-    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError) -> Self {
+    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError?) -> Self {
         state.errorTransform = errorTransform
         return self
     }

--- a/Sources/Authenticator/Views/SignInView.swift
+++ b/Sources/Authenticator/Views/SignInView.swift
@@ -127,7 +127,7 @@ public struct SignInView<Header: View,
 
     /// Sets a custom error mapping function for the `AuthError`s that are displayed
     /// - Parameter errorTransform: A closure that takes an `AuthError` and returns a ``AuthenticatorError`` that will be displayed.
-    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError) -> Self {
+    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError?) -> Self {
         state.errorTransform = errorTransform
         return self
     }

--- a/Sources/Authenticator/Views/SignUpView.swift
+++ b/Sources/Authenticator/Views/SignUpView.swift
@@ -91,7 +91,7 @@ public struct SignUpView<Header: View,
 
     /// Sets a custom error mapping function for the `AuthError`s that are displayed
     /// - Parameter errorTransform: A closure that takes an `AuthError` and returns a ``AuthenticatorError`` that will be displayed.
-    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError) -> Self {
+    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError?) -> Self {
         state.errorTransform = errorTransform
         return self
     }

--- a/Sources/Authenticator/Views/VerifyUserView.swift
+++ b/Sources/Authenticator/Views/VerifyUserView.swift
@@ -78,7 +78,7 @@ public struct VerifyUserView<Header: View,
 
     /// Sets a custom error mapping function for the `AuthError`s that are displayed
     /// - Parameter errorTransform: A closure that takes an `AuthError` and returns a ``AuthenticatorError`` that will be displayed.
-    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError) -> Self {
+    public func errorMap(_ errorTransform: @escaping (AuthError) -> AuthenticatorError?) -> Self {
         state.errorTransform = errorTransform
         return self
     }

--- a/Tests/AuthenticatorTests/States/AuthenticatorBaseStateTests.swift
+++ b/Tests/AuthenticatorTests/States/AuthenticatorBaseStateTests.swift
@@ -239,6 +239,22 @@ class AuthenticatorBaseStateTests: XCTestCase {
         XCTAssertEqual(authenticatorError.content, "A custom error")
     }
 
+    func testError_withCustomErrorTransformThatReturnsNil_shouldReturnDefaultError() {
+        var closureCount = 0
+        state.errorTransform = { error in
+            closureCount = 1
+            if case .service = error {
+                return .error(message: "A service error")
+            }
+            return nil
+        }
+        let authenticatorError = state.error(for: AuthError.notAuthorized("description", "recovery", nil))
+        XCTAssertEqual(closureCount, 1)
+        XCTAssertEqual(authenticatorError.style, .error)
+        let expectedMessage = "authenticator.authError.incorrectCredentials".localized()
+        XCTAssertEqual(authenticatorError.content, expectedMessage)
+    }
+
     func testError_withLocalizedCognitoError_shouldReturnLocalizedError() {
         let cognitoError = AWSCognitoAuthError.userNotFound
         let authenticatorError = state.error(for: AuthError.service("description", "recovery", cognitoError))


### PR DESCRIPTION
**Description of changes:**

This PR allows Authenticator customers to invoke the `errorMap(_:)` view modifiers without having to provide an `AuthenticatorError` for every possible `AuthError`. Instead, they can just provide a new value only for the errors they want to overwrite and return `nil` for all the rest, in which case the Authenticator will proceed to handle them with their default behaviour. 

For example, if a user only wants to override the message for `. notAuthorized` when a specific condition is met, they can now do something like:

```swift
Authenticator { _ in 
    // ....
}
.errorMap { error in
    if case .notAuthorized = error, anotherCondition {
        return .error(message: "A custom message for .notAuthorized")
    }
    
    return nil
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
