### PR TITLE
fix(Authenticator): Adding new error localizations for limits exceeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.8 (2024-09-20)
+
+### Bug Fixes
+- **Authenticator**: Adding new error localizations for limits exceeded (#96)
+
 ## 1.1.7 (2024-09-13)
 
 ### Bug Fixes

--- a/Sources/Authenticator/Constants/ComponentInformation.swift
+++ b/Sources/Authenticator/Constants/ComponentInformation.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 public class ComponentInformation {
-    public static let version = "1.1.7"
+    public static let version = "1.1.8"
     public static let name = "amplify-ui-swift-authenticator"
 }

--- a/Sources/Authenticator/Resources/en.lproj/Localizable.strings
+++ b/Sources/Authenticator/Resources/en.lproj/Localizable.strings
@@ -164,6 +164,7 @@
 
 /* Authenticator Errors */
 "authenticator.authError.incorrectCredentials" = "Incorrect username or password";
+"authenticator.authError.passwordAttemptsExceeded" = "You've reached the password attempts limit. Please try again later";
 "authenticator.authError.continueSignInWithMFASelection.noSelectionError" = "Please select an MFA method to continue";
 "authenticator.unknownError" = "Sorry, something went wrong";
 
@@ -174,6 +175,7 @@
 "authenticator.cognitoError.network" = "Please check your connectivity";
 "authenticator.cognitoError.usernameExists" = "Username already exists";
 "authenticator.cognitoError.userNotFound" = "User not found";
+"authenticator.cognitoError.limitExceeded" = "You've reached the request limit. Please try again later";
 
 /* Toolbar displayed on top of the keyboard */
 "authenticator.keyboardToolbar.Done" = "Done";

--- a/Sources/Authenticator/States/AuthenticatorBaseState.swift
+++ b/Sources/Authenticator/States/AuthenticatorBaseState.swift
@@ -197,8 +197,13 @@ public class AuthenticatorBaseState: ObservableObject {
     }
 
     private func localizedMessage(for error: AuthError) -> String? {
-        if case .notAuthorized(_, _, _) = error {
-            return "authenticator.authError.incorrectCredentials".localized()
+        if case .notAuthorized(let description, _, _) = error {
+            switch description {
+            case "Password attempts exceeded":
+                return "authenticator.authError.passwordAttemptsExceeded".localized()
+            default:
+                return "authenticator.authError.incorrectCredentials".localized()
+            }
         }
 
         if case .validation(let field, _, _, _) = error {

--- a/Tests/AuthenticatorTests/States/AuthenticatorBaseStateTests.swift
+++ b/Tests/AuthenticatorTests/States/AuthenticatorBaseStateTests.swift
@@ -221,8 +221,14 @@ class AuthenticatorBaseStateTests: XCTestCase {
         XCTAssertEqual(authenticatorError.content, "authenticator.unknownError".localized())
     }
 
-    func testError_withNotAuthorizedError_shouldReturnLocalizedError() {
-        let authenticatorError = state.error(for: AuthError.notAuthorized("description", "recovery", nil))
+    func testError_withNotAuthorizedError_withPasswordAttemptsExceededDescription_shouldReturnLocalizedError() {
+        let authenticatorError = state.error(for: AuthError.notAuthorized("Password attempts exceeded", "recovery", nil))
+        XCTAssertEqual(authenticatorError.style, .error)
+        XCTAssertEqual(authenticatorError.content, "authenticator.authError.passwordAttemptsExceeded".localized())
+    }
+
+    func testError_withNotAuthorizedError_withAnotherDescription_shouldReturnLocalizedError() {
+        let authenticatorError = state.error(for: AuthError.notAuthorized("Unable to sign in", "recovery", nil))
         XCTAssertEqual(authenticatorError.style, .error)
         XCTAssertEqual(authenticatorError.content, "authenticator.authError.incorrectCredentials".localized())
     }


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/amplify-ui-swift-authenticator/issues/83
- https://github.com/aws-amplify/amplify-ui-swift-authenticator/issues/92

**Description of changes:**

This PR adds new localization entries for the following errors coming from Cognito:
- `LimitExceededException`, mapped to a `AWSCognitoAuthError.limitExceeded` by Amplify
- `NotAuthorizedException` with a message of `"Password attempts exceeded"`, mapped to a `AuthError.notAuthorized` by Amplify.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
