### PR TITLE
fix: Avoiding signing out users when the token refresh fails due to no connectivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.3 (2024-12-16)
+
+### Bug Fixes
+- **Theming**: Adding support for customizing the TextFields' input and placeholder foreground colours (#100)
+- **Authenticator**: Avoiding signing out users when the token refresh fails due to no connectivity (#104)
+
 ## 1.2.2 (2024-11-26)
 
 ### Misc. Updates

--- a/Sources/Authenticator/Extensions/AuthError+Connectivity.swift
+++ b/Sources/Authenticator/Extensions/AuthError+Connectivity.swift
@@ -1,0 +1,26 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Foundation
+
+extension AuthError {
+    var isConnectivityError: Bool {
+        guard let error = underlyingError as? NSError else {
+            return false
+        }
+
+        let networkErrorCodes = [
+            NSURLErrorCannotFindHost,
+            NSURLErrorCannotConnectToHost,
+            NSURLErrorNetworkConnectionLost,
+            NSURLErrorDNSLookupFailed,
+            NSURLErrorNotConnectedToInternet
+        ]
+        return networkErrorCodes.contains(where: { $0 == error.code })
+    }
+}

--- a/Sources/Authenticator/Models/AuthenticatorState.swift
+++ b/Sources/Authenticator/Models/AuthenticatorState.swift
@@ -116,12 +116,17 @@ public class AuthenticatorState: ObservableObject, AuthenticatorStateProtocol {
             return session.isSignedIn
         }
 
-        if configuration.hasIdentityPool, case .failure(_) = cognitoSession.getIdentityId() {
+        // If the failures are caused due to connectivity errors, consider the session still valid
+        if configuration.hasIdentityPool,
+           case .failure(let authError) = cognitoSession.getIdentityId(),
+           !authError.isConnectivityError {
             log.verbose("Could not fetch Identity ID")
             return false
         }
 
-        if configuration.hasUserPool, case .failure(_) = cognitoSession.getCognitoTokens(){
+        if configuration.hasUserPool,
+           case .failure(let authError) = cognitoSession.getCognitoTokens(),
+           !authError.isConnectivityError {
             log.verbose("Could not fetch Cognito Tokens")
             return false
         }

--- a/Sources/Authenticator/States/AuthenticatorBaseState.swift
+++ b/Sources/Authenticator/States/AuthenticatorBaseState.swift
@@ -227,7 +227,7 @@ public class AuthenticatorBaseState: ObservableObject {
         }
 
         // First check if the underlying error is a connectivity one
-        if isConnectivityError(error.underlyingError) {
+        if error.isConnectivityError {
             log.verbose("The error is identified as a connectivity issue, displaying the corresponding localized string.")
             return "authenticator.cognitoError.network".localized()
         }
@@ -247,20 +247,6 @@ public class AuthenticatorBaseState: ObservableObject {
         
         log.verbose("No localizable string was found for error of type '\(cognitoError)'")
         return nil
-    }
-
-    private func isConnectivityError(_ error: Error?) -> Bool {
-        guard let error = error as? NSError else {
-            return false
-        }
-        let networkErrorCodes = [
-            NSURLErrorCannotFindHost,
-            NSURLErrorCannotConnectToHost,
-            NSURLErrorNetworkConnectionLost,
-            NSURLErrorDNSLookupFailed,
-            NSURLErrorNotConnectedToInternet
-        ]
-        return networkErrorCodes.contains(where: { $0 == error.code })
     }
 }
 


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/amplify-ui-swift-authenticator/issues/103

**Description of changes:**

This PRs fixes the issue when the access token is expired on launch but the device has no connectivity. 
Instead of just signing out the user, we'll keep them signed in. This is only done when the user was already signed in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
